### PR TITLE
CASIM-5: Changed the way the height of the status bar

### DIFF
--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -86,10 +86,16 @@ public class DatapathBuilder extends AbstractGUI
 	JScrollPane toolscroll;
 	public void reSize(int width, int height)
 	{
-		toolscroll.setBounds(0,0,toolcomponent.width+20,frameY-STATUSSIZE);
-		drawingcomponent.restoreSize();
-//		drawingcomponent.scroll.setBounds(toolcomponent.width+20,0,frameX-toolcomponent.width-20,frameY-STATUSSIZE);
-		drawingcomponent.scroll.revalidate();
+		// This is another place where we may be trying to scroll a pane/window but it 
+		// hasn't yet been fully realized.  So check first.
+		if (toolscroll == null) return;
+		
+		try {
+			toolscroll.setBounds(0,0,toolcomponent.width+20,frameY-STATUSSIZE);
+			drawingcomponent.restoreSize();
+	//		drawingcomponent.scroll.setBounds(toolcomponent.width+20,0,frameX-toolcomponent.width-20,frameY-STATUSSIZE);
+			drawingcomponent.scroll.revalidate();
+		} catch(Exception e) {}
 	}
 	public void constructGUI(GUIComponent guiComponent) 
 	{ 


### PR DESCRIPTION
Changed the way the calculation was done for the status bar so it was inside of the stage, not outside.  Outside seems to work (or more likely it is forced within) on a PC but not a Mac.

Also changed the border type so a vertical scrollbar would appear on a jframe as well.