### PR TITLE
Casim 6 - scaling

### DIFF
--- a/src/simulator/AbstractGUI.java
+++ b/src/simulator/AbstractGUI.java
@@ -53,11 +53,11 @@ public abstract class AbstractGUI extends JInternalFrame
 //			frameX=computer.computerGUI.getW(this);
 //			frameY=computer.computerGUI.getH(this);
 //		}
-		if (frameX>computer.resolution.desktopWindowWidth-MARGIN)
-			frameX=computer.resolution.desktopWindowWidth-MARGIN;
+		if (frameX>computer.resolution.desktop.width-MARGIN)
+			frameX=computer.resolution.desktop.width-MARGIN;
 		
-		if (frameY>computer.resolution.desktopWindowHeight-MARGIN)
-			frameY=computer.resolution.desktopWindowHeight-MARGIN;
+		if (frameY>computer.resolution.desktop.height-MARGIN)
+			frameY=computer.resolution.desktop.height-MARGIN;
 
 		setSize(frameX,frameY);
 		addInternalFrameListener(new GUIWindowListener());

--- a/src/simulator/AbstractGUI.java
+++ b/src/simulator/AbstractGUI.java
@@ -33,12 +33,28 @@ public abstract class AbstractGUI extends JInternalFrame
 	
 	protected Computer computer;
 	private AbstractGUI thisgui=this;
+	
+	public AbstractWindow resolution;
 
+	/*
+	 * All GUI windows need to be able to handle additional screen resolutions.  This
+	 * is part of an ongoing project. Therefore, we're overloading the constructor
+	 * to accommodate the old style of creating the GUI and the new style (with a
+	 * resolution parameter).
+	 */
 	public AbstractGUI(Computer computer, String title, int canvaswidth, int canvasheight, boolean statusbar, boolean scrollpane, boolean buttonrow, boolean bigScreen)
+	{
+		this(computer, title, statusbar, scrollpane, buttonrow, bigScreen, new AbstractWindow(canvaswidth, canvasheight));
+	}
+	
+	public AbstractGUI(Computer computer, String title, boolean statusbar, boolean scrollpane, boolean buttonrow, boolean bigScreen, AbstractWindow resolution)
 	{
 		super(title, true, true, true, true);
 		
+		int canvaswidth = resolution.width;
+		int canvasheight = resolution.height;
 		this.computer=computer;
+		this.resolution = resolution;
 		this.STATUSSIZE = computer.resolution.desktop.getStatusBarThickness();
 		this.scrollpane=scrollpane;
 		this.statusbar=statusbar;

--- a/src/simulator/AbstractGUI.java
+++ b/src/simulator/AbstractGUI.java
@@ -86,7 +86,7 @@ public abstract class AbstractGUI extends JInternalFrame
 			Border frameBorder=getBorder();
 			
 			frameBorder = ((javax.swing.border.CompoundBorder)frameBorder).getInsideBorder();
-			setBorder(BorderFactory.createCompoundBorder(BorderFactory.createLineBorder(Color.red,3), frameBorder));
+			setBorder(BorderFactory.createCompoundBorder(BorderFactory.createLineBorder(Color.black,1), frameBorder));
 		} catch (ClassCastException e) {
 			setBorder(BorderFactory.createLineBorder(Color.black, 1));
 		}

--- a/src/simulator/AbstractGUI.java
+++ b/src/simulator/AbstractGUI.java
@@ -12,7 +12,7 @@ import java.awt.event.*;
 
 public abstract class AbstractGUI extends JInternalFrame
 {
-	public static final int STATUSSIZE=50;
+	public static int STATUSSIZE=50;
 	public static final int BUTTONROWSIZE=30;
 	public static final int MARGIN=20;
 	public static final int MAX_X=10000,MAX_Y=7000;
@@ -39,7 +39,7 @@ public abstract class AbstractGUI extends JInternalFrame
 		super(title, true, true, true, true);
 		
 		this.computer=computer;
-		
+		this.STATUSSIZE = computer.resolution.desktop.getStatusBarThickness();
 		this.scrollpane=scrollpane;
 		this.statusbar=statusbar;
 		this.buttonrow=buttonrow;
@@ -71,6 +71,8 @@ public abstract class AbstractGUI extends JInternalFrame
 			
 			statusComponent = new StatusComponent();
 			statusComponent.setBounds(0,topy,frameX,STATUSSIZE);
+			statusComponent.setFont(new Font("Dialog",Font.ITALIC,computer.resolution.desktop.getFontSize()));
+			
 			statusComponent.setLabel("");
 			add(statusComponent);
 		}
@@ -166,8 +168,10 @@ public abstract class AbstractGUI extends JInternalFrame
 	}
 	public void setStatusLabel(String label)
 	{
-		if(statusComponent!=null)
+		if(statusComponent!=null) {
+			statusComponent.setFont(new Font("Dialog",Font.ITALIC,20));//computer.resolution.desktop.getFontSize()));
 			statusComponent.setLabel(label);
+		}
 	}
 
 	public void statusEdit(String baselabel, int exactlength, boolean hexonly)
@@ -327,7 +331,7 @@ public abstract class AbstractGUI extends JInternalFrame
 			g.setColor(Color.BLACK);
 			g.drawLine(0,0,frameX,0);
 
-			int fontSize=12;
+			int fontSize=computer.resolution.desktop.getFontSize();
 			g.setFont(new Font("Dialog",Font.BOLD,fontSize));
 			g.drawString(statusLabel,STATUSSIZE-MARGIN,fontSize);
 		}

--- a/src/simulator/AbstractGUI.java
+++ b/src/simulator/AbstractGUI.java
@@ -9,6 +9,7 @@ import javax.swing.event.InternalFrameListener;
 import java.awt.event.*;
 
 //TODO: there is a scrollpane (bool) and scrollPane (JScrollPane)
+// so????
 
 public abstract class AbstractGUI extends JInternalFrame
 {

--- a/src/simulator/AbstractGUI.java
+++ b/src/simulator/AbstractGUI.java
@@ -9,7 +9,6 @@ import javax.swing.event.InternalFrameListener;
 import java.awt.event.*;
 
 //TODO: there is a scrollpane (bool) and scrollPane (JScrollPane)
-// so????
 
 public abstract class AbstractGUI extends JInternalFrame
 {

--- a/src/simulator/AbstractGUI.java
+++ b/src/simulator/AbstractGUI.java
@@ -427,8 +427,14 @@ public abstract class AbstractGUI extends JInternalFrame
 		{
 			frameX=thisgui.getWidth();
 			frameY=thisgui.getHeight();
-			
-			/*
+            Boolean isMax =   ((JInternalFrame)e.getComponent()).isMaximum();
+
+            if(isMax)
+            {
+				frameX = thisgui.getParent().getWidth()-25;
+				thisgui.setSize(new Dimension(frameX, frameY));
+            }
+                /*
 			 * As the window components are being created, this method will be called to resize
 			 * based on the components.  This means that some components might not yet exist so
 			 * we need to check before doing anything with them.

--- a/src/simulator/AbstractGUI.java
+++ b/src/simulator/AbstractGUI.java
@@ -53,11 +53,11 @@ public abstract class AbstractGUI extends JInternalFrame
 //			frameX=computer.computerGUI.getW(this);
 //			frameY=computer.computerGUI.getH(this);
 //		}
-		if (frameX>computer.computerGUI.XSIZE-MARGIN)
-			frameX=ComputerGUI.XSIZE-MARGIN;
+		if (frameX>computer.resolution.desktopWindowWidth-MARGIN)
+			frameX=computer.resolution.desktopWindowWidth-MARGIN;
 		
-		if (frameY>computer.computerGUI.MAINSIZE-MARGIN)
-			frameY=ComputerGUI.MAINSIZE-MARGIN;
+		if (frameY>computer.resolution.desktopWindowHeight-MARGIN)
+			frameY=computer.resolution.desktopWindowHeight-MARGIN;
 
 		setSize(frameX,frameY);
 		addInternalFrameListener(new GUIWindowListener());

--- a/src/simulator/AbstractGUI.java
+++ b/src/simulator/AbstractGUI.java
@@ -84,7 +84,7 @@ public abstract class AbstractGUI extends JInternalFrame
 			Border frameBorder=getBorder();
 			
 			frameBorder = ((javax.swing.border.CompoundBorder)frameBorder).getInsideBorder();
-			setBorder(BorderFactory.createCompoundBorder(BorderFactory.createLineBorder(Color.black), frameBorder));
+			setBorder(BorderFactory.createCompoundBorder(BorderFactory.createLineBorder(Color.red,3), frameBorder));
 		} catch (ClassCastException e) {
 			setBorder(BorderFactory.createLineBorder(Color.black, 1));
 		}

--- a/src/simulator/AbstractWindow.java
+++ b/src/simulator/AbstractWindow.java
@@ -1,0 +1,53 @@
+package simulator;
+
+import javax.swing.UIManager;
+
+import simulator.Resolution.InnerPane;
+
+public class AbstractWindow {
+	protected final int BUTTON_COMPONENT_WIDTH = 100;
+	protected final int BUTTON_HEIGHT = 20;
+	protected final int STATUS_HEIGHT = 30;
+	protected final int DEFAULT_STATUS_BAR_THICKNESS = 35;
+	protected final int DEFAULT_SCROLL_BAR_THICKNESS = 15;
+	protected final int SCROLL_BAR_PADDING = 4;
+	
+	static double multiplier;
+
+	public int width;
+	public int height;	
+	public InnerPane pane;
+	private int fontSize = 10;
+
+	public AbstractWindow(int width, int height) {
+		this.width = width;
+		this.height = height;
+	}
+	public AbstractWindow() {
+		this(0, 0);
+	}
+	
+	public int getFontSize() {
+		return (int)(fontSize * multiplier);
+	}
+
+	public int getScrollbarWidth() {
+		return (int) UIManager.get("ScrollBar.width") + SCROLL_BAR_PADDING;
+	}
+	
+	public int getButtonHeight() {
+		return (int)(BUTTON_HEIGHT * multiplier);
+	}
+	
+	public int getButtonHeightAndSpace() {
+		return (int)(BUTTON_HEIGHT * multiplier + 5);
+	}
+	
+	public int getStatusBarThickness() {
+		return (int)(DEFAULT_STATUS_BAR_THICKNESS * multiplier);
+	}
+	
+	public int getScrollbarThickness() {
+		return (int)(DEFAULT_SCROLL_BAR_THICKNESS * multiplier);
+	}
+}

--- a/src/simulator/BootGUI.java
+++ b/src/simulator/BootGUI.java
@@ -668,13 +668,13 @@ public class BootGUI extends AbstractGUI
 	private class ButtonListener implements ActionListener
 	{
 		public void actionPerformed(ActionEvent e)
-		{
+		{ 
 			if (e.getActionCommand().equals("Boot Floppy A:"))
 			{
 				bootFromFloppy=true;
 				bootImageName=diskField[0].getText();
 				setVisible(false);
-				computer.computerGUI.menubar.setVisible(true);
+				computer.computerGUI.setMenubarVisible(true);
 				computer.computerGUI.removeComponent(bootgui);
 				computer.stepLock.lockResume();
 
@@ -684,7 +684,7 @@ public class BootGUI extends AbstractGUI
 				bootFromFloppy=false;
 				bootImageName=diskField[2].getText();
 				setVisible(false);
-				computer.computerGUI.menubar.setVisible(true);
+				computer.computerGUI.setMenubarVisible(true);
 				computer.computerGUI.removeComponent(bootgui);
 				computer.stepLock.lockResume();
 			}
@@ -693,7 +693,7 @@ public class BootGUI extends AbstractGUI
 				bootFromFloppy=false;
 				bootImageName="";
 				setVisible(false);
-				computer.computerGUI.menubar.setVisible(true);
+				computer.computerGUI.setMenubarVisible(true);
 				computer.computerGUI.removeComponent(bootgui);
 				singlestepbox.setSelected(true);
 				computer.stepLock.lockResume();
@@ -703,7 +703,7 @@ public class BootGUI extends AbstractGUI
 				bootFromFloppy=false;
 				bootImageName="";
 				setVisible(false);
-				computer.computerGUI.menubar.setVisible(true);
+				computer.computerGUI.setMenubarVisible(true);
 				computer.computerGUI.removeComponent(bootgui);
 				singlestepbox.setSelected(true);
 

--- a/src/simulator/Computer.java
+++ b/src/simulator/Computer.java
@@ -268,7 +268,11 @@ public class Computer
 
 		if (!bootgui.memoryImage.equals(""))
 		{
-			MemoryTransferGUI.load(bootgui.memoryImage, bootgui.memoryImageStart, this);
+			try {
+				MemoryTransferGUI.load(bootgui.memoryImage, bootgui.memoryImageStart, this);
+			} catch (NullPointerException e) {
+				System.out.println("Error loading memory image");
+			}
 		}
 		
 		if (!bootgui.datapathxml.equals(""))

--- a/src/simulator/Computer.java
+++ b/src/simulator/Computer.java
@@ -73,6 +73,7 @@ public class Computer
 	public ComputerApplet applet=null;
 	
 	public String args="";
+	public Resolution resolution;
 	
 	public String saveState()
 	{
@@ -177,12 +178,9 @@ public class Computer
 	{
 		stepLock=new Lock();
 		cycleEndLock=new Lock();
+		resolution = new Resolution();
 
-        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-        double screenWidth = screenSize.getWidth();
-        double screenHeight = screenSize.getHeight();
-
-        computerGUI = new ComputerGUI(computer, screenWidth, screenHeight);
+        computerGUI = new ComputerGUI(computer);
 
 		bootgui = new BootGUI(computer,new String[]{"Processor","Memory","BIOS ROM","VGA ROM","Registers","I/O Ports","Video","Keyboard","Floppy Controller","Interrupt Controller","IDE Controller","CMOS","Timer","DMA Controller","Serial Port"});
 

--- a/src/simulator/ComputerGUI.java
+++ b/src/simulator/ComputerGUI.java
@@ -111,16 +111,16 @@ public class ComputerGUI
     private void setStatusPanelBounds() {
 		statuspanel.setBounds(0, computer.resolution.desktop.pane.height-getMenubarOffset(),
 				computer.resolution.desktop.pane.width,
-				computer.resolution.desktop.getStatusBarThickness());
+				computer.resolution.desktop.getScrollbarThickness());
     }
     private void setStatusFieldBounds() {
 		statusfield.setBounds(0,0,
 				computer.resolution.desktop.width,
-				computer.resolution.desktop.getStatusBarThickness());
+				computer.resolution.desktop.getScrollbarThickness());
     }
     private void setButtonPanelBounds() {
 		buttonpanel.setBounds(0,
-				computer.resolution.desktop.pane.height+computer.resolution.desktop.getStatusBarThickness()-getMenubarOffset(),
+				computer.resolution.desktop.pane.height+computer.resolution.desktop.getScrollbarThickness()-getMenubarOffset(),
 				computer.resolution.desktop.pane.width,
 				computer.resolution.desktop.getButtonHeight());
     }

--- a/src/simulator/ComputerGUI.java
+++ b/src/simulator/ComputerGUI.java
@@ -47,9 +47,9 @@ public class ComputerGUI
 		if (computer.applet==null)
 		{
 			final JFrame computerFrame = new JFrame("Simulator v1.5");
-			setUIFont (new javax.swing.plaf.FontUIResource(Font.SANS_SERIF,Font.PLAIN,computer.resolution.getFontSize()+3));
-			computer.resolution.setScrollbars();
-			computerFrame.setSize(computer.resolution.desktopPanelWidth,computer.resolution.desktopWindowHeight);
+			setUIFont (new javax.swing.plaf.FontUIResource(Font.SANS_SERIF,Font.PLAIN,computer.resolution.desktop.getFontSize()+3));
+			computer.resolution.desktop.setScrollbars();
+			computerFrame.setSize(computer.resolution.desktop.width,computer.resolution.desktop.height);
 			computerFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 			computerFrame.setLayout(null);
 
@@ -63,7 +63,7 @@ public class ComputerGUI
 				public void componentMoved(ComponentEvent arg0) {}
 				public void componentResized(ComponentEvent arg0) 
 				{ 
-					computer.resolution.setDesktopDimensions(computerFrame.getWidth(), computerFrame.getHeight());
+					computer.resolution.desktop.setInnerPane(computerFrame.getWidth(), computerFrame.getHeight());
 
 					setDFrameBounds();
 					setStatusPanelBounds();
@@ -104,16 +104,25 @@ public class ComputerGUI
 		return 0;
 	}
     private void setDFrameBounds() {
-		dframe.setBounds(0,0,computer.resolution.desktopWindowWidth,computer.resolution.desktopPanelHeight - getMenubarOffset());
+		dframe.setBounds(0,0,
+				computer.resolution.desktop.width,
+				computer.resolution.desktop.pane.height - getMenubarOffset());
     }
     private void setStatusPanelBounds() {
-		statuspanel.setBounds(0,computer.resolution.desktopPanelHeight-getMenubarOffset(),computer.resolution.desktopPanelWidth,computer.resolution.statusHeight);
+		statuspanel.setBounds(0, computer.resolution.desktop.pane.height-getMenubarOffset(),
+				computer.resolution.desktop.pane.width,
+				computer.resolution.desktop.getStatusBarThickness());
     }
     private void setStatusFieldBounds() {
-		statusfield.setBounds(0,0,computer.resolution.desktopWindowWidth,computer.resolution.statusHeight);
+		statusfield.setBounds(0,0,
+				computer.resolution.desktop.width,
+				computer.resolution.desktop.getStatusBarThickness());
     }
     private void setButtonPanelBounds() {
-		buttonpanel.setBounds(0,computer.resolution.desktopPanelHeight+computer.resolution.statusHeight-getMenubarOffset(),computer.resolution.desktopPanelWidth,computer.resolution.buttonHeight);
+		buttonpanel.setBounds(0,
+				computer.resolution.desktop.pane.height+computer.resolution.desktop.getStatusBarThickness()-getMenubarOffset(),
+				computer.resolution.desktop.pane.width,
+				computer.resolution.desktop.getButtonHeight());
     }
 	JMenuBar menubar;
 	private JMenuBar constructMenuBar()
@@ -879,7 +888,9 @@ public class ComputerGUI
 //		dframe.repaint();
 		if (paintNext||(computer.ioGUI!=null &&(computer.ioGUI.portRead||computer.ioGUI.portWrite||computer.ioGUI.interruptRequested||computer.ioGUI.interruptTriggered)))
 		{
-			dframe.paintImmediately(0, 0, computer.resolution.desktopPanelWidth,computer.resolution.desktopPanelHeight);
+			dframe.paintImmediately(0, 0, 
+					computer.resolution.desktop.pane.width,
+					computer.resolution.desktop.pane.height);
 			paintNext=false;
 		}
 		else if (computer.memoryGUI!=null && (computer.memoryGUI.memoryRead||computer.memoryGUI.memoryWrite||computer.memoryGUI.romRead))

--- a/src/simulator/ComputerGUI.java
+++ b/src/simulator/ComputerGUI.java
@@ -47,7 +47,7 @@ public class ComputerGUI
 		if (computer.applet==null)
 		{
 			final JFrame computerFrame = new JFrame("Simulator v1.5");
-			setUIFont (new javax.swing.plaf.FontUIResource(Font.SANS_SERIF,Font.PLAIN,computer.resolution.getFontSize()));
+			setUIFont (new javax.swing.plaf.FontUIResource(Font.SANS_SERIF,Font.PLAIN,computer.resolution.getFontSize()+3));
 			computerFrame.setSize(computer.resolution.desktopPanelWidth,computer.resolution.desktopWindowHeight);
 			computerFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 			computerFrame.setLayout(null);

--- a/src/simulator/ComputerGUI.java
+++ b/src/simulator/ComputerGUI.java
@@ -48,6 +48,7 @@ public class ComputerGUI
 		{
 			final JFrame computerFrame = new JFrame("Simulator v1.5");
 			setUIFont (new javax.swing.plaf.FontUIResource(Font.SANS_SERIF,Font.PLAIN,computer.resolution.getFontSize()+3));
+			computer.resolution.setScrollbars();
 			computerFrame.setSize(computer.resolution.desktopPanelWidth,computer.resolution.desktopWindowHeight);
 			computerFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 			computerFrame.setLayout(null);
@@ -81,7 +82,7 @@ public class ComputerGUI
 			computer.applet.panel.revalidate();
 		}
 	}
-    public static void setUIFont (javax.swing.plaf.FontUIResource f){
+    public void setUIFont (javax.swing.plaf.FontUIResource f){
         java.util.Enumeration keys = UIManager.getDefaults().keys();
         while (keys.hasMoreElements()) {
           Object key = keys.nextElement();

--- a/src/simulator/ComputerGUI.java
+++ b/src/simulator/ComputerGUI.java
@@ -47,6 +47,7 @@ public class ComputerGUI
 		if (computer.applet==null)
 		{
 			final JFrame computerFrame = new JFrame("Simulator v1.5");
+			setUIFont (new javax.swing.plaf.FontUIResource(Font.SANS_SERIF,Font.PLAIN,computer.resolution.getFontSize()));
 			computerFrame.setSize(computer.resolution.desktopPanelWidth,computer.resolution.desktopWindowHeight);
 			computerFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 			computerFrame.setLayout(null);
@@ -80,6 +81,15 @@ public class ComputerGUI
 			computer.applet.panel.revalidate();
 		}
 	}
+    public static void setUIFont (javax.swing.plaf.FontUIResource f){
+        java.util.Enumeration keys = UIManager.getDefaults().keys();
+        while (keys.hasMoreElements()) {
+          Object key = keys.nextElement();
+          Object value = UIManager.get (key);
+          if (value instanceof javax.swing.plaf.FontUIResource)
+            UIManager.put (key, f);
+          }
+        } 
 	public void setMenubarVisible(boolean visible) {
 		menubar.setVisible(visible);
 		setDFrameBounds();

--- a/src/simulator/ComputerGUI.java
+++ b/src/simulator/ComputerGUI.java
@@ -18,26 +18,18 @@ import simulator.DatapathBuilder.DatapathModule;
 
 public class ComputerGUI
 {
-	static int XSIZE = 1000;
-	static int YSIZE = 730;
-
-	static int BUTTONSIZE = 100;
-	static int STATUSSIZE = 30;
-	static int MAINSIZE = YSIZE - BUTTONSIZE - STATUSSIZE;
 	
 	private static final int INSTRUCTION_COUNT_UPDATE=50000;
-//	static int BIGWIDTH=(int)(0.6*XSIZE),BIGHEIGHT=(int)(0.62*YSIZE);
+
 	Computer computer;
 	JDesktopPane dframe;
 	boolean singleFrame=true;
 	JTextField statusfield;
 	JPanel buttonpanel,statuspanel;
 	
-    public ComputerGUI(Computer computer, double screenWidth, double screenHeight)
+    public ComputerGUI(Computer computer)
 	{
 		this.computer=computer;
-		this.XSIZE = (int) (screenWidth * .5);
-		this.YSIZE = (int) (screenHeight * .8);
 		
 /*        try {
             for (javax.swing.UIManager.LookAndFeelInfo info : javax.swing.UIManager.getInstalledLookAndFeels()) {
@@ -56,15 +48,15 @@ public class ComputerGUI
         }		
 */		
 		dframe=new ComputerDesktopPane();
-		dframe.setBounds(0,0,XSIZE,MAINSIZE);
+		dframe.setBounds(0,0,computer.resolution.desktopPanelWidth,computer.resolution.desktopPanelHeight);
 		buttonpanel=new JPanel();
-		buttonpanel.setBounds(0,MAINSIZE+STATUSSIZE,XSIZE,BUTTONSIZE);
+		buttonpanel.setBounds(0,computer.resolution.desktopPanelHeight+computer.resolution.statusHeight,computer.resolution.desktopPanelWidth,computer.resolution.buttonHeight);
 		generateButtons(buttonpanel);
 		statuspanel=new JPanel();
-		statuspanel.setBounds(0,MAINSIZE,XSIZE,STATUSSIZE);
+		statuspanel.setBounds(0,computer.resolution.desktopPanelHeight,computer.resolution.desktopPanelWidth,computer.resolution.statusHeight);
 		statuspanel.setLayout(null);
 		statusfield=new JTextField();
-		statusfield.setBounds(0,0,XSIZE,STATUSSIZE);
+		statusfield.setBounds(0,0,computer.resolution.desktopPanelWidth,computer.resolution.statusHeight);
 		statusfield.setFont(statusfield.getFont().deriveFont(statusfield.getFont().getStyle() ^ Font.BOLD));
 		statuspanel.add(statusfield);
 		
@@ -72,7 +64,7 @@ public class ComputerGUI
 		if (computer.applet==null)
 		{
 			final JFrame computerFrame = new JFrame("Simulator");
-			computerFrame.setSize(XSIZE,YSIZE);
+			computerFrame.setSize(computer.resolution.desktopPanelWidth,computer.resolution.desktopPanelHeight);
 			computerFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 			computerFrame.setLayout(null);
 
@@ -86,13 +78,12 @@ public class ComputerGUI
 				public void componentMoved(ComponentEvent arg0) {}
 				public void componentResized(ComponentEvent arg0) 
 				{ 
-					XSIZE=computerFrame.getWidth();
-					YSIZE=computerFrame.getHeight();
-					MAINSIZE=YSIZE-BUTTONSIZE-STATUSSIZE;
-					dframe.setBounds(0,0,XSIZE,MAINSIZE);
-					statuspanel.setBounds(0,MAINSIZE,XSIZE,STATUSSIZE);
-					statusfield.setBounds(0,0,XSIZE,STATUSSIZE);
-					buttonpanel.setBounds(0,MAINSIZE+STATUSSIZE,XSIZE,BUTTONSIZE);
+					computer.resolution.setDesktopDimensions(computerFrame.getWidth(), computerFrame.getHeight());
+
+					dframe.setBounds(0,0,computer.resolution.desktopWindowWidth,computer.resolution.desktopWindowHeight);
+					statuspanel.setBounds(0,computer.resolution.desktopWindowHeight,computer.resolution.desktopWindowWidth,computer.resolution.statusHeight);
+					statusfield.setBounds(0,0,computer.resolution.desktopWindowWidth,computer.resolution.statusHeight);
+					buttonpanel.setBounds(0,computer.resolution.desktopWindowHeight+computer.resolution.statusHeight,computer.resolution.desktopWindowWidth,computer.resolution.buttonWidth);
 				}
 				public void componentShown(ComponentEvent arg0) {}
 				});
@@ -871,7 +862,7 @@ public class ComputerGUI
 //		dframe.repaint();
 		if (paintNext||(computer.ioGUI!=null &&(computer.ioGUI.portRead||computer.ioGUI.portWrite||computer.ioGUI.interruptRequested||computer.ioGUI.interruptTriggered)))
 		{
-			dframe.paintImmediately(0, 0, XSIZE,YSIZE);
+			dframe.paintImmediately(0, 0, computer.resolution.desktopPanelWidth,computer.resolution.desktopPanelHeight);
 			paintNext=false;
 		}
 		else if (computer.memoryGUI!=null && (computer.memoryGUI.memoryRead||computer.memoryGUI.memoryWrite||computer.memoryGUI.romRead))

--- a/src/simulator/ComputerGUI.java
+++ b/src/simulator/ComputerGUI.java
@@ -30,48 +30,31 @@ public class ComputerGUI
     public ComputerGUI(Computer computer)
 	{
 		this.computer=computer;
-		
-/*        try {
-            for (javax.swing.UIManager.LookAndFeelInfo info : javax.swing.UIManager.getInstalledLookAndFeels()) {
-//            	System.out.println(info.getName());
-                if ("Nimbus".equals(info.getName())) {
-                    javax.swing.UIManager.setLookAndFeel(info.getClassName());
-                 
-                    break;
-                
-                }
-            }
-        } catch (ClassNotFoundException ex) {
-        } catch (InstantiationException ex) {
-        } catch (IllegalAccessException ex) {
-         } catch (javax.swing.UnsupportedLookAndFeelException ex) {
-        }		
-*/		
+		constructMenuBar();
 		dframe=new ComputerDesktopPane();
-		dframe.setBounds(0,0,computer.resolution.desktopPanelWidth,computer.resolution.desktopPanelHeight);
+		setDFrameBounds();
 		buttonpanel=new JPanel();
-		buttonpanel.setBounds(0,computer.resolution.desktopPanelHeight+computer.resolution.statusHeight,computer.resolution.desktopPanelWidth,computer.resolution.buttonHeight);
+		setButtonPanelBounds();
 		generateButtons(buttonpanel);
 		statuspanel=new JPanel();
-		statuspanel.setBounds(0,computer.resolution.desktopPanelHeight,computer.resolution.desktopPanelWidth,computer.resolution.statusHeight);
+		setStatusPanelBounds();
 		statuspanel.setLayout(null);
 		statusfield=new JTextField();
-		statusfield.setBounds(0,0,computer.resolution.desktopPanelWidth,computer.resolution.statusHeight);
+		setStatusFieldBounds();
 		statusfield.setFont(statusfield.getFont().deriveFont(statusfield.getFont().getStyle() ^ Font.BOLD));
 		statuspanel.add(statusfield);
 		
-		
 		if (computer.applet==null)
 		{
-			final JFrame computerFrame = new JFrame("Simulator");
-			computerFrame.setSize(computer.resolution.desktopPanelWidth,computer.resolution.desktopPanelHeight);
+			final JFrame computerFrame = new JFrame("Simulator v1.5");
+			computerFrame.setSize(computer.resolution.desktopPanelWidth,computer.resolution.desktopWindowHeight);
 			computerFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 			computerFrame.setLayout(null);
 
 			computerFrame.add(statuspanel);
 			computerFrame.add(buttonpanel);
 			computerFrame.add(dframe);
-			computerFrame.setJMenuBar(constructMenuBar());
+			computerFrame.setJMenuBar(menubar);
 			computerFrame.setVisible(true);
 			computerFrame.addComponentListener(new ComponentListener(){
 				public void componentHidden(ComponentEvent arg0) {}
@@ -80,10 +63,10 @@ public class ComputerGUI
 				{ 
 					computer.resolution.setDesktopDimensions(computerFrame.getWidth(), computerFrame.getHeight());
 
-					dframe.setBounds(0,0,computer.resolution.desktopWindowWidth,computer.resolution.desktopWindowHeight);
-					statuspanel.setBounds(0,computer.resolution.desktopWindowHeight,computer.resolution.desktopWindowWidth,computer.resolution.statusHeight);
-					statusfield.setBounds(0,0,computer.resolution.desktopWindowWidth,computer.resolution.statusHeight);
-					buttonpanel.setBounds(0,computer.resolution.desktopWindowHeight+computer.resolution.statusHeight,computer.resolution.desktopWindowWidth,computer.resolution.buttonWidth);
+					setDFrameBounds();
+					setStatusPanelBounds();
+					setStatusFieldBounds();
+					setButtonPanelBounds();
 				}
 				public void componentShown(ComponentEvent arg0) {}
 				});
@@ -97,7 +80,30 @@ public class ComputerGUI
 			computer.applet.panel.revalidate();
 		}
 	}
-	
+	public void setMenubarVisible(boolean visible) {
+		menubar.setVisible(visible);
+		setDFrameBounds();
+		setStatusPanelBounds();
+		setStatusFieldBounds();
+		setButtonPanelBounds();
+	}
+	private int getMenubarOffset() {
+		if (menubar.isVisible())
+			return menubar.getHeight();
+		return 0;
+	}
+    private void setDFrameBounds() {
+		dframe.setBounds(0,0,computer.resolution.desktopWindowWidth,computer.resolution.desktopPanelHeight - getMenubarOffset());
+    }
+    private void setStatusPanelBounds() {
+		statuspanel.setBounds(0,computer.resolution.desktopPanelHeight-getMenubarOffset(),computer.resolution.desktopPanelWidth,computer.resolution.statusHeight);
+    }
+    private void setStatusFieldBounds() {
+		statusfield.setBounds(0,0,computer.resolution.desktopWindowWidth,computer.resolution.statusHeight);
+    }
+    private void setButtonPanelBounds() {
+		buttonpanel.setBounds(0,computer.resolution.desktopPanelHeight+computer.resolution.statusHeight-getMenubarOffset(),computer.resolution.desktopPanelWidth,computer.resolution.buttonHeight);
+    }
 	JMenuBar menubar;
 	private JMenuBar constructMenuBar()
 	{

--- a/src/simulator/ComputerGUI.java
+++ b/src/simulator/ComputerGUI.java
@@ -47,6 +47,7 @@ public class ComputerGUI
 		if (computer.applet==null)
 		{
 			final JFrame computerFrame = new JFrame("Simulator " + Version.version);
+
 			setUIFont (new javax.swing.plaf.FontUIResource(Font.SANS_SERIF,Font.PLAIN,computer.resolution.desktop.getFontSize()+3));
 			computer.resolution.desktop.setScrollbars();
 			computerFrame.setSize(computer.resolution.desktop.width,computer.resolution.desktop.height);
@@ -105,7 +106,7 @@ public class ComputerGUI
 	}
     private void setDFrameBounds() {
 		dframe.setBounds(0,0,
-				computer.resolution.desktop.width,
+				computer.resolution.desktop.pane.width,
 				computer.resolution.desktop.pane.height - getMenubarOffset());
     }
     private void setStatusPanelBounds() {
@@ -115,7 +116,7 @@ public class ComputerGUI
     }
     private void setStatusFieldBounds() {
 		statusfield.setBounds(0,0,
-				computer.resolution.desktop.width,
+				computer.resolution.desktop.pane.width,
 				computer.resolution.desktop.getScrollbarThickness());
     }
     private void setButtonPanelBounds() {

--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -1089,7 +1089,7 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			
-			height = frameY > ctop ? frameY : ctop;
+			height = computer.resolution.screenHeight > ctop ? computer.resolution.screenHeight : ctop;
 			saveChanges.setEnabled(true);
 			add(saveChanges);
 			

--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -46,7 +46,7 @@ public class DatapathBuilder extends AbstractGUI
 	public int gridsize=3;
 //	public int blocknumber=1;
 	public int defaultbits=1;
-	
+
 	private ToolComponent toolcomponent;
 	private DrawingComponent drawingcomponent;
 	private ModificationComponent modificationcomponent;
@@ -68,6 +68,7 @@ public class DatapathBuilder extends AbstractGUI
 		super(computer,"Datapath Builder",
 				computer.resolution.datapath.width,
 				computer.resolution.datapath.height,true,false,false,true);
+	
 		undolog=new Stack<String>();
 		modules=new ArrayList<CustomProcessorModule>();
 		errorlog=new ArrayList<ErrorEntry>();

--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -31,6 +31,8 @@ import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 
+import com.sun.javafx.geom.Rectangle;
+
 import simulator.CustomProcessor.CustomProcessorModule;
 
 public class DatapathBuilder extends AbstractGUI
@@ -100,7 +102,7 @@ public class DatapathBuilder extends AbstractGUI
 			// Change the height of the main gui container and the tool scroll.
 			guiComponent.setBounds(0, 0, width, height);
 			if (toolscroll != null)
-				toolscroll.setBounds(0,0,toolcomponent.width+20,height-STATUSSIZE);
+				toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.getScrollbarWidth(),height-STATUSSIZE);
 
 			if (drawingcomponent != null) {
 				drawingcomponent.restoreSize();
@@ -120,7 +122,7 @@ public class DatapathBuilder extends AbstractGUI
 		this.guiComponent = guiComponent;
 		toolcomponent=new ToolComponent();
 		toolscroll=new JScrollPane(toolcomponent);
-		toolscroll.setBounds(0,0,toolcomponent.width+20,frameY-STATUSSIZE);
+		toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.getScrollbarWidth(),frameY-STATUSSIZE);
 		guiComponent.add(toolscroll);
 		drawingcomponent=new DrawingComponent();
 		guiComponent.add(drawingcomponent.scroll);
@@ -1101,7 +1103,7 @@ public class DatapathBuilder extends AbstractGUI
 			
 		}
 		public void restoreSize() {
-			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + MARGIN,frameY-STATUSSIZE);
+			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + computer.resolution.getScrollbarWidth(),frameY-STATUSSIZE);
 			drawingcomponent.setLeft(toolscroll.getWidth() + width + MARGIN);
 			drawingcomponent.restoreSize();
 		}
@@ -1489,6 +1491,7 @@ public class DatapathBuilder extends AbstractGUI
 			super();
 			resetLeft();
 			scroll=new JScrollPane(this);
+			//scroll.getVerticalScrollBar().setPreferredSize(new Dimension(44, 0));
 			restoreSize();
 			scroll.getHorizontalScrollBar().setValue(dpwidth/2);
 			scroll.getVerticalScrollBar().setValue(dpheight/2);

--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -73,7 +73,7 @@ public class DatapathBuilder extends AbstractGUI
 		errorlog=new ArrayList<ErrorEntry>();
 		defaultModule=new DatapathModule();
 		undolog.push(dumpXML());
-		scaling = computer.resolution.getScalingFactor();
+		scaling = computer.resolution.datapath.getScalingFactor();
 		refresh();
 	}
 
@@ -104,7 +104,7 @@ public class DatapathBuilder extends AbstractGUI
 			// Change the height of the main gui container and the tool scroll.
 			guiComponent.setBounds(0, 0, width, height);
 			if (toolscroll != null)
-				toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.datapath.toolComponent.getScrollbarWidth(),height-STATUSSIZE);
+				toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.datapath.toolComponent.getScrollbarWidth(),height-computer.resolution.datapath.getStatusBarThickness());
 
 			if (drawingcomponent != null) {
 				drawingcomponent.restoreSize();
@@ -124,7 +124,7 @@ public class DatapathBuilder extends AbstractGUI
 		this.guiComponent = guiComponent;
 		toolcomponent=new ToolComponent();
 		toolscroll=new JScrollPane(toolcomponent);
-		toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.datapath.toolComponent.getScrollbarWidth(),frameY-STATUSSIZE);
+		toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.datapath.toolComponent.getScrollbarWidth(),frameY-computer.resolution.datapath.getStatusBarThickness());
 		guiComponent.add(toolscroll);
 		drawingcomponent=new DrawingComponent();
 		guiComponent.add(drawingcomponent.scroll);
@@ -1105,7 +1105,7 @@ public class DatapathBuilder extends AbstractGUI
 			
 		}
 		public void restoreSize() {
-			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + computer.resolution.datapath.toolComponent.getScrollbarWidth(),frameY-STATUSSIZE);
+			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + computer.resolution.datapath.toolComponent.getScrollbarWidth(),frameY-computer.resolution.datapath.getStatusBarThickness());
 			drawingcomponent.setLeft(toolscroll.getWidth() + width + MARGIN);
 			drawingcomponent.restoreSize();
 		}
@@ -1521,7 +1521,7 @@ public class DatapathBuilder extends AbstractGUI
 				}});
 		}
 		public void restoreSize() {
-			scroll.setBounds(left,0,frameX-left,frameY-STATUSSIZE);			
+			scroll.setBounds(left,0,frameX-left,frameY-computer.resolution.datapath.getStatusBarThickness());			
 		}
 		int left;
 		public void setLeft(int left) {

--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -896,7 +896,8 @@ public class DatapathBuilder extends AbstractGUI
 
 	public class ModificationComponent extends JComponent
 	{
-		int width=100, height=1000;
+		int width=100;
+		int height=computer.resolution.newComponentHeight;
 		JLabel[] itemlabel;
 		JTextField[] itemfield;
 		JButton saveChanges;
@@ -1015,23 +1016,23 @@ public class DatapathBuilder extends AbstractGUI
 			else
 				itemlabel[0]=new JLabel("Bus "+bu.number);
 			itemlabel[0].setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
-			itemlabel[0].setBounds(5,ctop+=50,cwidth,45);
+			itemlabel[0].setBounds(5,ctop+=computer.resolution.getButtonHeightAndSpace(),cwidth,computer.resolution.getButtonHeight());
 			add(itemlabel[0]);
 
 			for (int i=1; i<TYPES; i++)
 			{
 				if (itemfield[i].isVisible())
 				{
-					itemlabel[i].setBounds(5,ctop+=50,cwidth,45);
+					itemlabel[i].setBounds(5,ctop+=computer.resolution.getButtonHeightAndSpace(),cwidth,computer.resolution.getButtonHeight());
 					add(itemlabel[i]);
-					itemfield[i].setBounds(5,ctop+=50,cwidth,45);
+					itemfield[i].setBounds(5,ctop+=computer.resolution.getButtonHeightAndSpace(),cwidth,computer.resolution.getButtonHeight());
 					add(itemfield[i]);
 				}
 			}
 
 			saveChanges=new JButton("Update");
 			saveChanges.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			saveChanges.setBounds(5,ctop+=50,cwidth,45);
+			saveChanges.setBounds(5,ctop+=computer.resolution.getButtonHeightAndSpace(),cwidth,computer.resolution.getButtonHeight());
 			saveChanges.setVisible(true);
 			saveChanges.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1087,6 +1088,8 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.repaint();
 					drawingcomponent.requestFocus();
 				}});
+			
+			height = frameY > ctop ? frameY : ctop;
 			saveChanges.setEnabled(true);
 			add(saveChanges);
 			
@@ -1095,6 +1098,7 @@ public class DatapathBuilder extends AbstractGUI
 			guiComponent.add(modificationScroll);
 			restoreSize();
 			guiComponent.revalidate();
+			
 		}
 		public void restoreSize() {
 			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + MARGIN,frameY-STATUSSIZE);
@@ -1125,12 +1129,13 @@ public class DatapathBuilder extends AbstractGUI
 	
 	public class ToolComponent extends JComponent
 	{
-		int width=100, height=2000;
+		int width=100;
+		int height;
 		int line1,line2;
 		
 		public Dimension getPreferredSize()
 		{
-			return new Dimension(width,height);
+			return new Dimension(width, height);
 		}
 		public ToolComponent()
 		{
@@ -1145,27 +1150,27 @@ public class DatapathBuilder extends AbstractGUI
 						
 			button=new JButton("Close");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Close this window.  All unsaved work will be lost.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					close();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Load");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Load a previously saved datapath from an xml file");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					doload();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Save");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Save the datapath as an xml file");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1193,10 +1198,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Export");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Save the datapath as an Arduino C program");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1224,10 +1229,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("ExportVerilog");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Save the datapath as a Verilog program");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1255,10 +1260,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Undo");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Undo the last modification made to the datapath (also the Z key)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1266,10 +1271,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Unselect All");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Unselect all datapath blocks (also done by right-clicking on an empty area)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1277,10 +1282,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Mass Select");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Select all blocks in a rectangular region");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1288,10 +1293,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Duplicate");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Paste a new copy of all selected blocks");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1299,10 +1304,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Delete");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("All selected blocks are removed (also DEL key)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1310,10 +1315,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Verify");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Check for errors in the datapath.  Blocks with errors are selected.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1321,10 +1326,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Zoom In");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					scaling+=0.2;
@@ -1332,10 +1337,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Zoom Out");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					scaling-=0.2;
@@ -1344,10 +1349,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Control");
 			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Open up a new Control Builder window");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1361,10 +1366,10 @@ public class DatapathBuilder extends AbstractGUI
 					}
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			button=new JButton("Simulate");
 			button.setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,45);
+			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			button.setToolTipText("Start running your datapath.  If a datapath is already running, stop it.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1385,15 +1390,15 @@ public class DatapathBuilder extends AbstractGUI
 					}
 				}});
 			add(button);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 
 			line1=ctop;
 			ctop+=5;
 			label=new JLabel("Place a new:");
 			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
-			label.setBounds(5,ctop,cwidth,45);
+			label.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			add(label);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			
 			int tooltipnumber=0;
 			String[] tooltips=new String[]{"A set of wires that connect the output of one block to the input of another (also the B key)","merge several buses together to form a larger bus.  buses on the left form the high order bits of the output bus","extract a subset of wires from a bus to form a smaller bus","a storage unit that saves a value on each clock cycle.  registers can be enabled/disabled with the control unit, or with a one-bit enabler bus connecting to the side","a one-bit register","a table of registers.  an address bus connected to the side selects a register from the table","connect to physical memory. an address input bus connects to the side, data to the top and bottom","connect to the simulated I/O ports.  port is selected with an address bus connected to the side, data buses connects to the top and bottom.","routes one or more input buses to a single output bus.  selection can be done with a side-connected bus or from the control unit.  input buses are numbered from 0 starting at the left.","has one input bus of b width, and 2^b output buses.  one of the output buses is chosen based on the value at the input and set to 1.","2-input unit that can do various arithmetic operations. the operation is selected by the control unit.","transfer the value from a smaller bus to a larger bus, preserving the sign","source a constant hexadecimal value.  the name of the block is the value sourced","a simple ROM that holds a truth table.  the output is selected from a side address input.","sources a value chosen by the user at runtime","displays a value at runtime","connect a bus to the control unit.  the bus's value can be used to make conditional control statements","load a previously designed datapath/control into the datapath as a single block","draw a text label on the datapath"};
@@ -1401,7 +1406,7 @@ public class DatapathBuilder extends AbstractGUI
 			{
 				button=new JButton(s);
 				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-				button.setBounds(5,ctop,cwidth,45);
+				button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 				button.setToolTipText(tooltips[tooltipnumber++]);
 				final String s2=s;
 				button.addActionListener(new ActionListener(){
@@ -1434,21 +1439,21 @@ public class DatapathBuilder extends AbstractGUI
 						drawingcomponent.requestFocus();
 					}});
 				add(button);
-				ctop+=50;				
+				ctop+=computer.resolution.getButtonHeightAndSpace();				
 			}
 
 			line2=ctop;
 			ctop+=5;
 			label=new JLabel("Combinational:");
 			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
-			label.setBounds(5,ctop,cwidth,45);
+			label.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 			add(label);
-			ctop+=50;
+			ctop+=computer.resolution.getButtonHeightAndSpace();
 			for (String s:new String[]{"adder","negate","increment","decrement","and","or","nand","nor","not","xor","equal-to","less-than","shift-left","shift-right"})
 			{
 				button=new JButton(s);
 				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-				button.setBounds(5,ctop,cwidth,45);
+				button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
 				final String s2="combinational-"+s;
 				button.addActionListener(new ActionListener(){
 					public void actionPerformed(ActionEvent arg0) {
@@ -1459,8 +1464,9 @@ public class DatapathBuilder extends AbstractGUI
 						drawingcomponent.requestFocus();
 					}});
 				add(button);
-				ctop+=50;				
+				ctop+=computer.resolution.getButtonHeightAndSpace();				
 			}
+			height = ctop;
 		}
 		public void paintComponent(Graphics g)
 		{

--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -31,8 +31,6 @@ import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 
-import com.sun.javafx.geom.Rectangle;
-
 import simulator.CustomProcessor.CustomProcessorModule;
 
 public class DatapathBuilder extends AbstractGUI

--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -38,7 +38,7 @@ public class DatapathBuilder extends AbstractGUI
 //	private ArrayList<Block> blocks;
 //	private ArrayList<Bus> buses;
 	public DatapathModule defaultModule;
-	public double scaling=1.6;
+	public double scaling;
 	public int xshift=0,yshift=0;
 	public int dpwidth=2000, dpheight=2000;
 	public int gridsize=3;
@@ -48,7 +48,8 @@ public class DatapathBuilder extends AbstractGUI
 	private ToolComponent toolcomponent;
 	private DrawingComponent drawingcomponent;
 	private ModificationComponent modificationcomponent;
-	
+	private 	JScrollPane modificationScroll;
+
 	private class ErrorEntry{int number; String error; public ErrorEntry(int number, String error){this.number=number; this.error=error;}}
 	public ArrayList<ErrorEntry> errorlog;
 	
@@ -62,12 +63,13 @@ public class DatapathBuilder extends AbstractGUI
 
 	public DatapathBuilder(Computer computer)
 	{
-		super(computer,"Datapath Builder",1000,700,true,false,false,true);
+		super(computer,"Datapath Builder",computer.resolution.newComponentWidth,computer.resolution.newComponentHeight,true,false,false,true);
 		undolog=new Stack<String>();
 		modules=new ArrayList<CustomProcessorModule>();
 		errorlog=new ArrayList<ErrorEntry>();
 		defaultModule=new DatapathModule();
 		undolog.push(dumpXML());
+		scaling = computer.resolution.getScalingFactor();
 		refresh();
 	}
 
@@ -905,26 +907,25 @@ public class DatapathBuilder extends AbstractGUI
 		
 		int currentBlock;
 		int currentBus;
-		JScrollPane scroll;
 
 		public ModificationComponent(int block,int bus)
 		{
 			super();
 			currentBlock=block; 
 			currentBus=bus;
+			width = computer.resolution.getDatapathModificationComponentWidth();
 			int ctop=0;
 			itemlabel=new JLabel[TYPES];
 			itemfield=new JTextField[TYPES];
-			int fontSize=10;
 			int cwidth=width-10;
 
 			
 			for (int i=1; i<TYPES; i++)
 			{
 				itemlabel[i]=new JLabel(labels[i]);
-				itemlabel[i].setFont(new Font("Dialog",Font.BOLD,fontSize));
+				itemlabel[i].setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
 				itemfield[i]=new JTextField("");
-				itemfield[i].setFont(new Font("Dialog",Font.PLAIN,fontSize));
+				itemfield[i].setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
 				itemfield[i].setText("");
 				itemfield[i].setEnabled(true);
 				itemfield[i].setVisible(false);
@@ -1013,24 +1014,24 @@ public class DatapathBuilder extends AbstractGUI
 				itemlabel[0]=new JLabel(b.type+" "+b.number);
 			else
 				itemlabel[0]=new JLabel("Bus "+bu.number);
-			itemlabel[0].setFont(new Font("Dialog",Font.BOLD,fontSize));
-			itemlabel[0].setBounds(5,ctop+=25,cwidth,20);
+			itemlabel[0].setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
+			itemlabel[0].setBounds(5,ctop+=50,cwidth,45);
 			add(itemlabel[0]);
 
 			for (int i=1; i<TYPES; i++)
 			{
 				if (itemfield[i].isVisible())
 				{
-					itemlabel[i].setBounds(5,ctop+=25,cwidth,20);
+					itemlabel[i].setBounds(5,ctop+=50,cwidth,45);
 					add(itemlabel[i]);
-					itemfield[i].setBounds(5,ctop+=25,cwidth,20);
+					itemfield[i].setBounds(5,ctop+=50,cwidth,45);
 					add(itemfield[i]);
 				}
 			}
 
 			saveChanges=new JButton("Update");
-			saveChanges.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			saveChanges.setBounds(5,ctop+=25,cwidth,20);
+			saveChanges.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			saveChanges.setBounds(5,ctop+=50,cwidth,45);
 			saveChanges.setVisible(true);
 			saveChanges.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1089,14 +1090,14 @@ public class DatapathBuilder extends AbstractGUI
 			saveChanges.setEnabled(true);
 			add(saveChanges);
 			
-			scroll=new JScrollPane(this);
+			modificationScroll=new JScrollPane(this);
 
-			guiComponent.add(scroll);
+			guiComponent.add(modificationScroll);
 			restoreSize();
 			guiComponent.revalidate();
 		}
 		public void restoreSize() {
-			scroll.setBounds(toolscroll.getWidth(), 0,width + MARGIN,frameY-STATUSSIZE);
+			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + MARGIN,frameY-STATUSSIZE);
 			drawingcomponent.setLeft(toolscroll.getWidth() + width + MARGIN);
 			drawingcomponent.restoreSize();
 		}
@@ -1113,8 +1114,9 @@ public class DatapathBuilder extends AbstractGUI
 		}
 		public void dispose()
 		{
-			guiComponent.remove(scroll);
+			guiComponent.remove(modificationScroll);
 			modificationcomponent=null;
+			modificationScroll = null;
 			drawingcomponent.resetLeft();
 			drawingcomponent.restoreSize();
 			guiComponent.revalidate();
@@ -1135,34 +1137,35 @@ public class DatapathBuilder extends AbstractGUI
 			super();
 			int ctop=10;
 			
+			width = computer.resolution.getDatapathToolComponentWidth();
+			
 			JButton button;
 			JLabel label;
-			int fontSize=10;
 			int cwidth=width-10;
 						
 			button=new JButton("Close");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Close this window.  All unsaved work will be lost.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					close();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Load");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Load a previously saved datapath from an xml file");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					doload();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Save");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Save the datapath as an xml file");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1190,10 +1193,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Export");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Save the datapath as an Arduino C program");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1221,10 +1224,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("ExportVerilog");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Save the datapath as a Verilog program");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1252,10 +1255,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Undo");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Undo the last modification made to the datapath (also the Z key)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1263,10 +1266,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Unselect All");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Unselect all datapath blocks (also done by right-clicking on an empty area)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1274,10 +1277,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Mass Select");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Select all blocks in a rectangular region");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1285,10 +1288,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Duplicate");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Paste a new copy of all selected blocks");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1296,10 +1299,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Delete");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("All selected blocks are removed (also DEL key)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1307,10 +1310,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Verify");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Check for errors in the datapath.  Blocks with errors are selected.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1318,10 +1321,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Zoom In");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					scaling+=0.2;
@@ -1329,10 +1332,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Zoom Out");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					scaling-=0.2;
@@ -1341,10 +1344,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Control");
-			button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Open up a new Control Builder window");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1358,10 +1361,10 @@ public class DatapathBuilder extends AbstractGUI
 					}
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 			button=new JButton("Simulate");
-			button.setFont(new Font("Dialog",Font.BOLD,fontSize));
-			button.setBounds(5,ctop,cwidth,20);
+			button.setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
+			button.setBounds(5,ctop,cwidth,45);
 			button.setToolTipText("Start running your datapath.  If a datapath is already running, stop it.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1382,23 +1385,23 @@ public class DatapathBuilder extends AbstractGUI
 					}
 				}});
 			add(button);
-			ctop+=25;
+			ctop+=50;
 
 			line1=ctop;
 			ctop+=5;
 			label=new JLabel("Place a new:");
-			label.setFont(new Font("Dialog",Font.BOLD,fontSize));
-			label.setBounds(5,ctop,cwidth,20);
+			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
+			label.setBounds(5,ctop,cwidth,45);
 			add(label);
-			ctop+=25;
+			ctop+=50;
 			
 			int tooltipnumber=0;
 			String[] tooltips=new String[]{"A set of wires that connect the output of one block to the input of another (also the B key)","merge several buses together to form a larger bus.  buses on the left form the high order bits of the output bus","extract a subset of wires from a bus to form a smaller bus","a storage unit that saves a value on each clock cycle.  registers can be enabled/disabled with the control unit, or with a one-bit enabler bus connecting to the side","a one-bit register","a table of registers.  an address bus connected to the side selects a register from the table","connect to physical memory. an address input bus connects to the side, data to the top and bottom","connect to the simulated I/O ports.  port is selected with an address bus connected to the side, data buses connects to the top and bottom.","routes one or more input buses to a single output bus.  selection can be done with a side-connected bus or from the control unit.  input buses are numbered from 0 starting at the left.","has one input bus of b width, and 2^b output buses.  one of the output buses is chosen based on the value at the input and set to 1.","2-input unit that can do various arithmetic operations. the operation is selected by the control unit.","transfer the value from a smaller bus to a larger bus, preserving the sign","source a constant hexadecimal value.  the name of the block is the value sourced","a simple ROM that holds a truth table.  the output is selected from a side address input.","sources a value chosen by the user at runtime","displays a value at runtime","connect a bus to the control unit.  the bus's value can be used to make conditional control statements","load a previously designed datapath/control into the datapath as a single block","draw a text label on the datapath"};
 			for (String s:new String[]{"bus","joiner","splitter","register","flag","register file","memory","ports","multiplexor","decoder","ALU","extender","constant","lookup table","input pin","output pin","control","module","label"})
 			{
 				button=new JButton(s);
-				button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-				button.setBounds(5,ctop,cwidth,20);
+				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+				button.setBounds(5,ctop,cwidth,45);
 				button.setToolTipText(tooltips[tooltipnumber++]);
 				final String s2=s;
 				button.addActionListener(new ActionListener(){
@@ -1431,21 +1434,21 @@ public class DatapathBuilder extends AbstractGUI
 						drawingcomponent.requestFocus();
 					}});
 				add(button);
-				ctop+=25;				
+				ctop+=50;				
 			}
 
 			line2=ctop;
 			ctop+=5;
 			label=new JLabel("Combinational:");
-			label.setFont(new Font("Dialog",Font.BOLD,fontSize));
-			label.setBounds(5,ctop,cwidth,20);
+			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
+			label.setBounds(5,ctop,cwidth,45);
 			add(label);
-			ctop+=25;
+			ctop+=50;
 			for (String s:new String[]{"adder","negate","increment","decrement","and","or","nand","nor","not","xor","equal-to","less-than","shift-left","shift-right"})
 			{
 				button=new JButton(s);
-				button.setFont(new Font("Dialog",Font.PLAIN,fontSize));
-				button.setBounds(5,ctop,cwidth,20);
+				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+				button.setBounds(5,ctop,cwidth,45);
 				final String s2="combinational-"+s;
 				button.addActionListener(new ActionListener(){
 					public void actionPerformed(ActionEvent arg0) {
@@ -1456,7 +1459,7 @@ public class DatapathBuilder extends AbstractGUI
 						drawingcomponent.requestFocus();
 					}});
 				add(button);
-				ctop+=25;				
+				ctop+=50;				
 			}
 		}
 		public void paintComponent(Graphics g)
@@ -1507,13 +1510,18 @@ public class DatapathBuilder extends AbstractGUI
 				}});
 		}
 		public void restoreSize() {
-			scroll.setBounds(left,0,frameX-toolscroll.getWidth(),frameY-STATUSSIZE);			
+			scroll.setBounds(left,0,frameX-left,frameY-STATUSSIZE);			
 		}
 		int left;
 		public void setLeft(int left) {
-			this.left = left;
+			//this.left = left;
+			this.left = toolscroll.getWidth();
+			if (modificationScroll != null) 
+				if (modificationScroll.isVisible())
+					this.left += modificationScroll.getWidth();
 		}
 		public void resetLeft() {
+			//this.left = toolscroll.getWidth();
 			setLeft(toolscroll.getWidth());
 		}
 		public Dimension getPreferredSize()

--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -62,19 +62,24 @@ public class DatapathBuilder extends AbstractGUI
 	private Stack<String> undolog;
 	public ArrayList<CustomProcessor.CustomProcessorModule> modules;
 	private GUIComponent guiComponent;
-
+	
+	private Resolution.Datapath resolution;
+	private Resolution.Desktop desktopResolution;
+	
 	public DatapathBuilder(Computer computer)
 	{
-		super(computer,"Datapath Builder",
-				computer.resolution.datapath.width,
-				computer.resolution.datapath.height,true,false,false,true);
+		super(computer,"Datapath Builder", true,false,false,true,
+				computer.resolution.datapath);
 	
+		resolution = computer.resolution.datapath;
+		desktopResolution = computer.resolution.desktop;
+		
 		undolog=new Stack<String>();
 		modules=new ArrayList<CustomProcessorModule>();
 		errorlog=new ArrayList<ErrorEntry>();
 		defaultModule=new DatapathModule();
 		undolog.push(dumpXML());
-		scaling = computer.resolution.datapath.getScalingFactor();
+		scaling = resolution.getScalingFactor();
 		refresh();
 	}
 
@@ -105,7 +110,7 @@ public class DatapathBuilder extends AbstractGUI
 			// Change the height of the main gui container and the tool scroll.
 			guiComponent.setBounds(0, 0, width, height);
 			if (toolscroll != null)
-				toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.datapath.toolComponent.getScrollbarWidth(),height-computer.resolution.datapath.getStatusBarThickness());
+				toolscroll.setBounds(0,0,toolcomponent.width+resolution.toolComponent.getScrollbarWidth(),height-resolution.getStatusBarThickness());
 
 			if (drawingcomponent != null) {
 				drawingcomponent.restoreSize();
@@ -125,7 +130,7 @@ public class DatapathBuilder extends AbstractGUI
 		this.guiComponent = guiComponent;
 		toolcomponent=new ToolComponent();
 		toolscroll=new JScrollPane(toolcomponent);
-		toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.datapath.toolComponent.getScrollbarWidth(),frameY-computer.resolution.datapath.getStatusBarThickness());
+		toolscroll.setBounds(0,0,toolcomponent.width+resolution.toolComponent.getScrollbarWidth(),frameY-resolution.getStatusBarThickness());
 		guiComponent.add(toolscroll);
 		drawingcomponent=new DrawingComponent();
 		guiComponent.add(drawingcomponent.scroll);
@@ -902,7 +907,7 @@ public class DatapathBuilder extends AbstractGUI
 	public class ModificationComponent extends JComponent
 	{
 		int width=100;
-		int height=computer.resolution.desktop.pane.height;
+		int height=desktopResolution.pane.height;
 		JLabel[] itemlabel;
 		JTextField[] itemfield;
 		JButton saveChanges;
@@ -919,7 +924,7 @@ public class DatapathBuilder extends AbstractGUI
 			super();
 			currentBlock=block; 
 			currentBus=bus;
-			width = computer.resolution.datapath.modificationComponent.width;
+			width = resolution.modificationComponent.width;
 			int ctop=0;
 			itemlabel=new JLabel[TYPES];
 			itemfield=new JTextField[TYPES];
@@ -929,9 +934,9 @@ public class DatapathBuilder extends AbstractGUI
 			for (int i=1; i<TYPES; i++)
 			{
 				itemlabel[i]=new JLabel(labels[i]);
-				itemlabel[i].setFont(new Font("Dialog",Font.BOLD,computer.resolution.desktop.getFontSize()));
+				itemlabel[i].setFont(new Font("Dialog",Font.BOLD,desktopResolution.getFontSize()));
 				itemfield[i]=new JTextField("");
-				itemfield[i].setFont(new Font("Dialog",Font.PLAIN,computer.resolution.desktop.getFontSize()));
+				itemfield[i].setFont(new Font("Dialog",Font.PLAIN,desktopResolution.getFontSize()));
 				itemfield[i].setText("");
 				itemfield[i].setEnabled(true);
 				itemfield[i].setVisible(false);
@@ -1020,24 +1025,24 @@ public class DatapathBuilder extends AbstractGUI
 				itemlabel[0]=new JLabel(b.type+" "+b.number);
 			else
 				itemlabel[0]=new JLabel("Bus "+bu.number);
-			itemlabel[0].setFont(new Font("Dialog",Font.BOLD,computer.resolution.desktop.getFontSize()));
-			itemlabel[0].setBounds(5,ctop+=computer.resolution.datapath.modificationComponent.getButtonHeightAndSpace(),cwidth,computer.resolution.datapath.modificationComponent.getButtonHeight());
+			itemlabel[0].setFont(new Font("Dialog",Font.BOLD,desktopResolution.getFontSize()));
+			itemlabel[0].setBounds(5,ctop+=resolution.modificationComponent.getButtonHeightAndSpace(),cwidth,resolution.modificationComponent.getButtonHeight());
 			add(itemlabel[0]);
 
 			for (int i=1; i<TYPES; i++)
 			{
 				if (itemfield[i].isVisible())
 				{
-					itemlabel[i].setBounds(5,ctop+=computer.resolution.datapath.modificationComponent.getButtonHeightAndSpace(),cwidth,computer.resolution.datapath.modificationComponent.getButtonHeight());
+					itemlabel[i].setBounds(5,ctop+=resolution.modificationComponent.getButtonHeightAndSpace(),cwidth,resolution.modificationComponent.getButtonHeight());
 					add(itemlabel[i]);
-					itemfield[i].setBounds(5,ctop+=computer.resolution.datapath.modificationComponent.getButtonHeightAndSpace(),cwidth,computer.resolution.datapath.modificationComponent.getButtonHeight());
+					itemfield[i].setBounds(5,ctop+=resolution.modificationComponent.getButtonHeightAndSpace(),cwidth,resolution.modificationComponent.getButtonHeight());
 					add(itemfield[i]);
 				}
 			}
 
 			saveChanges=new JButton("Update");
-			saveChanges.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.desktop.getFontSize()));
-			saveChanges.setBounds(5,ctop+=computer.resolution.datapath.modificationComponent.getButtonHeightAndSpace(),cwidth,computer.resolution.datapath.modificationComponent.getButtonHeight());
+			saveChanges.setFont(new Font("Dialog",Font.PLAIN,desktopResolution.getFontSize()));
+			saveChanges.setBounds(5,ctop+=resolution.modificationComponent.getButtonHeightAndSpace(),cwidth,resolution.modificationComponent.getButtonHeight());
 			saveChanges.setVisible(true);
 			saveChanges.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1106,7 +1111,7 @@ public class DatapathBuilder extends AbstractGUI
 			
 		}
 		public void restoreSize() {
-			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + computer.resolution.datapath.toolComponent.getScrollbarWidth(),frameY-computer.resolution.datapath.getStatusBarThickness());
+			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + resolution.toolComponent.getScrollbarWidth(),frameY-resolution.getStatusBarThickness());
 			drawingcomponent.setLeft(toolscroll.getWidth() + width + MARGIN);
 			drawingcomponent.restoreSize();
 		}
@@ -1147,35 +1152,35 @@ public class DatapathBuilder extends AbstractGUI
 			super();
 			int ctop=10;
 			
-			width = computer.resolution.datapath.toolComponent.width;
+			width = resolution.toolComponent.width;
 			
 			JButton button;
 			JLabel label;
 			int cwidth=width-10;
 						
 			button=new JButton("Close");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Close this window.  All unsaved work will be lost.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					close();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Load");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Load a previously saved datapath from an xml file");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					doload();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Save");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Save the datapath as an xml file");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1203,10 +1208,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Export");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Save the datapath as an Arduino C program");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1234,10 +1239,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("ExportVerilog");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Save the datapath as a Verilog program");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1265,10 +1270,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Undo");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Undo the last modification made to the datapath (also the Z key)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1276,10 +1281,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Unselect All");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Unselect all datapath blocks (also done by right-clicking on an empty area)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1287,10 +1292,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Mass Select");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Select all blocks in a rectangular region");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1298,10 +1303,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Duplicate");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Paste a new copy of all selected blocks");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1309,10 +1314,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Delete");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("All selected blocks are removed (also DEL key)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1320,10 +1325,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Verify");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Check for errors in the datapath.  Blocks with errors are selected.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1331,10 +1336,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Zoom In");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					scaling+=0.2;
@@ -1342,10 +1347,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Zoom Out");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					scaling-=0.2;
@@ -1354,10 +1359,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Control");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Open up a new Control Builder window");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1371,10 +1376,10 @@ public class DatapathBuilder extends AbstractGUI
 					}
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Simulate");
-			button.setFont(new Font("Dialog",Font.BOLD,computer.resolution.datapath.toolComponent.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.BOLD,resolution.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			button.setToolTipText("Start running your datapath.  If a datapath is already running, stop it.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1395,23 +1400,23 @@ public class DatapathBuilder extends AbstractGUI
 					}
 				}});
 			add(button);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 
 			line1=ctop;
 			ctop+=5;
 			label=new JLabel("Place a new:");
-			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.datapath.toolComponent.getFontSize()));
-			label.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			label.setFont(new Font("Dialog",Font.BOLD,resolution.toolComponent.getFontSize()));
+			label.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			add(label);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			
 			int tooltipnumber=0;
 			String[] tooltips=new String[]{"A set of wires that connect the output of one block to the input of another (also the B key)","merge several buses together to form a larger bus.  buses on the left form the high order bits of the output bus","extract a subset of wires from a bus to form a smaller bus","a storage unit that saves a value on each clock cycle.  registers can be enabled/disabled with the control unit, or with a one-bit enabler bus connecting to the side","a one-bit register","a table of registers.  an address bus connected to the side selects a register from the table","connect to physical memory. an address input bus connects to the side, data to the top and bottom","connect to the simulated I/O ports.  port is selected with an address bus connected to the side, data buses connects to the top and bottom.","routes one or more input buses to a single output bus.  selection can be done with a side-connected bus or from the control unit.  input buses are numbered from 0 starting at the left.","has one input bus of b width, and 2^b output buses.  one of the output buses is chosen based on the value at the input and set to 1.","2-input unit that can do various arithmetic operations. the operation is selected by the control unit.","transfer the value from a smaller bus to a larger bus, preserving the sign","source a constant hexadecimal value.  the name of the block is the value sourced","a simple ROM that holds a truth table.  the output is selected from a side address input.","sources a value chosen by the user at runtime","displays a value at runtime","connect a bus to the control unit.  the bus's value can be used to make conditional control statements","load a previously designed datapath/control into the datapath as a single block","draw a text label on the datapath"};
 			for (String s:new String[]{"bus","joiner","splitter","register","flag","register file","memory","ports","multiplexor","decoder","ALU","extender","constant","lookup table","input pin","output pin","control","module","label"})
 			{
 				button=new JButton(s);
-				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-				button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+				button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+				button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 				button.setToolTipText(tooltips[tooltipnumber++]);
 				final String s2=s;
 				button.addActionListener(new ActionListener(){
@@ -1444,21 +1449,21 @@ public class DatapathBuilder extends AbstractGUI
 						drawingcomponent.requestFocus();
 					}});
 				add(button);
-				ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();				
+				ctop+=resolution.toolComponent.getButtonHeightAndSpace();				
 			}
 
 			line2=ctop;
 			ctop+=5;
 			label=new JLabel("Combinational:");
-			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.datapath.toolComponent.getFontSize()));
-			label.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+			label.setFont(new Font("Dialog",Font.BOLD,resolution.toolComponent.getFontSize()));
+			label.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 			add(label);
-			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
+			ctop+=resolution.toolComponent.getButtonHeightAndSpace();
 			for (String s:new String[]{"adder","negate","increment","decrement","and","or","nand","nor","not","xor","equal-to","less-than","shift-left","shift-right"})
 			{
 				button=new JButton(s);
-				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
-				button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
+				button.setFont(new Font("Dialog",Font.PLAIN,resolution.toolComponent.getFontSize()));
+				button.setBounds(5,ctop,cwidth,resolution.toolComponent.getButtonHeight());
 				final String s2="combinational-"+s;
 				button.addActionListener(new ActionListener(){
 					public void actionPerformed(ActionEvent arg0) {
@@ -1469,7 +1474,7 @@ public class DatapathBuilder extends AbstractGUI
 						drawingcomponent.requestFocus();
 					}});
 				add(button);
-				ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();				
+				ctop+=resolution.toolComponent.getButtonHeightAndSpace();				
 			}
 			height = ctop;
 		}
@@ -1522,7 +1527,7 @@ public class DatapathBuilder extends AbstractGUI
 				}});
 		}
 		public void restoreSize() {
-			scroll.setBounds(left,0,frameX-left,frameY-computer.resolution.datapath.getStatusBarThickness());			
+			scroll.setBounds(left,0,frameX-left,frameY-resolution.getStatusBarThickness());			
 		}
 		int left;
 		public void setLeft(int left) {

--- a/src/simulator/DatapathBuilder.java
+++ b/src/simulator/DatapathBuilder.java
@@ -65,7 +65,9 @@ public class DatapathBuilder extends AbstractGUI
 
 	public DatapathBuilder(Computer computer)
 	{
-		super(computer,"Datapath Builder",computer.resolution.newComponentWidth,computer.resolution.newComponentHeight,true,false,false,true);
+		super(computer,"Datapath Builder",
+				computer.resolution.datapath.width,
+				computer.resolution.datapath.height,true,false,false,true);
 		undolog=new Stack<String>();
 		modules=new ArrayList<CustomProcessorModule>();
 		errorlog=new ArrayList<ErrorEntry>();
@@ -102,7 +104,7 @@ public class DatapathBuilder extends AbstractGUI
 			// Change the height of the main gui container and the tool scroll.
 			guiComponent.setBounds(0, 0, width, height);
 			if (toolscroll != null)
-				toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.getScrollbarWidth(),height-STATUSSIZE);
+				toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.datapath.toolComponent.getScrollbarWidth(),height-STATUSSIZE);
 
 			if (drawingcomponent != null) {
 				drawingcomponent.restoreSize();
@@ -122,7 +124,7 @@ public class DatapathBuilder extends AbstractGUI
 		this.guiComponent = guiComponent;
 		toolcomponent=new ToolComponent();
 		toolscroll=new JScrollPane(toolcomponent);
-		toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.getScrollbarWidth(),frameY-STATUSSIZE);
+		toolscroll.setBounds(0,0,toolcomponent.width+computer.resolution.datapath.toolComponent.getScrollbarWidth(),frameY-STATUSSIZE);
 		guiComponent.add(toolscroll);
 		drawingcomponent=new DrawingComponent();
 		guiComponent.add(drawingcomponent.scroll);
@@ -899,7 +901,7 @@ public class DatapathBuilder extends AbstractGUI
 	public class ModificationComponent extends JComponent
 	{
 		int width=100;
-		int height=computer.resolution.newComponentHeight;
+		int height=computer.resolution.desktop.pane.height;
 		JLabel[] itemlabel;
 		JTextField[] itemfield;
 		JButton saveChanges;
@@ -916,7 +918,7 @@ public class DatapathBuilder extends AbstractGUI
 			super();
 			currentBlock=block; 
 			currentBus=bus;
-			width = computer.resolution.getDatapathModificationComponentWidth();
+			width = computer.resolution.datapath.modificationComponent.width;
 			int ctop=0;
 			itemlabel=new JLabel[TYPES];
 			itemfield=new JTextField[TYPES];
@@ -926,9 +928,9 @@ public class DatapathBuilder extends AbstractGUI
 			for (int i=1; i<TYPES; i++)
 			{
 				itemlabel[i]=new JLabel(labels[i]);
-				itemlabel[i].setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
+				itemlabel[i].setFont(new Font("Dialog",Font.BOLD,computer.resolution.desktop.getFontSize()));
 				itemfield[i]=new JTextField("");
-				itemfield[i].setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
+				itemfield[i].setFont(new Font("Dialog",Font.PLAIN,computer.resolution.desktop.getFontSize()));
 				itemfield[i].setText("");
 				itemfield[i].setEnabled(true);
 				itemfield[i].setVisible(false);
@@ -1017,24 +1019,24 @@ public class DatapathBuilder extends AbstractGUI
 				itemlabel[0]=new JLabel(b.type+" "+b.number);
 			else
 				itemlabel[0]=new JLabel("Bus "+bu.number);
-			itemlabel[0].setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
-			itemlabel[0].setBounds(5,ctop+=computer.resolution.getButtonHeightAndSpace(),cwidth,computer.resolution.getButtonHeight());
+			itemlabel[0].setFont(new Font("Dialog",Font.BOLD,computer.resolution.desktop.getFontSize()));
+			itemlabel[0].setBounds(5,ctop+=computer.resolution.datapath.modificationComponent.getButtonHeightAndSpace(),cwidth,computer.resolution.datapath.modificationComponent.getButtonHeight());
 			add(itemlabel[0]);
 
 			for (int i=1; i<TYPES; i++)
 			{
 				if (itemfield[i].isVisible())
 				{
-					itemlabel[i].setBounds(5,ctop+=computer.resolution.getButtonHeightAndSpace(),cwidth,computer.resolution.getButtonHeight());
+					itemlabel[i].setBounds(5,ctop+=computer.resolution.datapath.modificationComponent.getButtonHeightAndSpace(),cwidth,computer.resolution.datapath.modificationComponent.getButtonHeight());
 					add(itemlabel[i]);
-					itemfield[i].setBounds(5,ctop+=computer.resolution.getButtonHeightAndSpace(),cwidth,computer.resolution.getButtonHeight());
+					itemfield[i].setBounds(5,ctop+=computer.resolution.datapath.modificationComponent.getButtonHeightAndSpace(),cwidth,computer.resolution.datapath.modificationComponent.getButtonHeight());
 					add(itemfield[i]);
 				}
 			}
 
 			saveChanges=new JButton("Update");
-			saveChanges.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			saveChanges.setBounds(5,ctop+=computer.resolution.getButtonHeightAndSpace(),cwidth,computer.resolution.getButtonHeight());
+			saveChanges.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.desktop.getFontSize()));
+			saveChanges.setBounds(5,ctop+=computer.resolution.datapath.modificationComponent.getButtonHeightAndSpace(),cwidth,computer.resolution.datapath.modificationComponent.getButtonHeight());
 			saveChanges.setVisible(true);
 			saveChanges.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1091,7 +1093,7 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			
-			height = computer.resolution.screenHeight > ctop ? computer.resolution.screenHeight : ctop;
+			height = computer.resolution.monitor.height > ctop ? computer.resolution.monitor.height : ctop;
 			saveChanges.setEnabled(true);
 			add(saveChanges);
 			
@@ -1103,7 +1105,7 @@ public class DatapathBuilder extends AbstractGUI
 			
 		}
 		public void restoreSize() {
-			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + computer.resolution.getScrollbarWidth(),frameY-STATUSSIZE);
+			modificationScroll.setBounds(toolscroll.getWidth(), 0,width + computer.resolution.datapath.toolComponent.getScrollbarWidth(),frameY-STATUSSIZE);
 			drawingcomponent.setLeft(toolscroll.getWidth() + width + MARGIN);
 			drawingcomponent.restoreSize();
 		}
@@ -1144,35 +1146,35 @@ public class DatapathBuilder extends AbstractGUI
 			super();
 			int ctop=10;
 			
-			width = computer.resolution.getDatapathToolComponentWidth();
+			width = computer.resolution.datapath.toolComponent.width;
 			
 			JButton button;
 			JLabel label;
 			int cwidth=width-10;
 						
 			button=new JButton("Close");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Close this window.  All unsaved work will be lost.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					close();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Load");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Load a previously saved datapath from an xml file");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					doload();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Save");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Save the datapath as an xml file");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1200,10 +1202,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Export");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Save the datapath as an Arduino C program");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1231,10 +1233,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("ExportVerilog");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Save the datapath as a Verilog program");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1262,10 +1264,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Undo");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Undo the last modification made to the datapath (also the Z key)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1273,10 +1275,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Unselect All");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Unselect all datapath blocks (also done by right-clicking on an empty area)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1284,10 +1286,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Mass Select");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Select all blocks in a rectangular region");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1295,10 +1297,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Duplicate");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Paste a new copy of all selected blocks");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1306,10 +1308,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Delete");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("All selected blocks are removed (also DEL key)");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1317,10 +1319,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Verify");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Check for errors in the datapath.  Blocks with errors are selected.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1328,10 +1330,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Zoom In");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					scaling+=0.2;
@@ -1339,10 +1341,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Zoom Out");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
 					scaling-=0.2;
@@ -1351,10 +1353,10 @@ public class DatapathBuilder extends AbstractGUI
 					drawingcomponent.requestFocus();
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Control");
-			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Open up a new Control Builder window");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1368,10 +1370,10 @@ public class DatapathBuilder extends AbstractGUI
 					}
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			button=new JButton("Simulate");
-			button.setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
-			button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			button.setFont(new Font("Dialog",Font.BOLD,computer.resolution.datapath.toolComponent.getFontSize()));
+			button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			button.setToolTipText("Start running your datapath.  If a datapath is already running, stop it.");
 			button.addActionListener(new ActionListener(){
 				public void actionPerformed(ActionEvent arg0) {
@@ -1392,23 +1394,23 @@ public class DatapathBuilder extends AbstractGUI
 					}
 				}});
 			add(button);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 
 			line1=ctop;
 			ctop+=5;
 			label=new JLabel("Place a new:");
-			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
-			label.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.datapath.toolComponent.getFontSize()));
+			label.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			add(label);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			
 			int tooltipnumber=0;
 			String[] tooltips=new String[]{"A set of wires that connect the output of one block to the input of another (also the B key)","merge several buses together to form a larger bus.  buses on the left form the high order bits of the output bus","extract a subset of wires from a bus to form a smaller bus","a storage unit that saves a value on each clock cycle.  registers can be enabled/disabled with the control unit, or with a one-bit enabler bus connecting to the side","a one-bit register","a table of registers.  an address bus connected to the side selects a register from the table","connect to physical memory. an address input bus connects to the side, data to the top and bottom","connect to the simulated I/O ports.  port is selected with an address bus connected to the side, data buses connects to the top and bottom.","routes one or more input buses to a single output bus.  selection can be done with a side-connected bus or from the control unit.  input buses are numbered from 0 starting at the left.","has one input bus of b width, and 2^b output buses.  one of the output buses is chosen based on the value at the input and set to 1.","2-input unit that can do various arithmetic operations. the operation is selected by the control unit.","transfer the value from a smaller bus to a larger bus, preserving the sign","source a constant hexadecimal value.  the name of the block is the value sourced","a simple ROM that holds a truth table.  the output is selected from a side address input.","sources a value chosen by the user at runtime","displays a value at runtime","connect a bus to the control unit.  the bus's value can be used to make conditional control statements","load a previously designed datapath/control into the datapath as a single block","draw a text label on the datapath"};
 			for (String s:new String[]{"bus","joiner","splitter","register","flag","register file","memory","ports","multiplexor","decoder","ALU","extender","constant","lookup table","input pin","output pin","control","module","label"})
 			{
 				button=new JButton(s);
-				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-				button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+				button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 				button.setToolTipText(tooltips[tooltipnumber++]);
 				final String s2=s;
 				button.addActionListener(new ActionListener(){
@@ -1441,21 +1443,21 @@ public class DatapathBuilder extends AbstractGUI
 						drawingcomponent.requestFocus();
 					}});
 				add(button);
-				ctop+=computer.resolution.getButtonHeightAndSpace();				
+				ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();				
 			}
 
 			line2=ctop;
 			ctop+=5;
 			label=new JLabel("Combinational:");
-			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.getFontSize()));
-			label.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+			label.setFont(new Font("Dialog",Font.BOLD,computer.resolution.datapath.toolComponent.getFontSize()));
+			label.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 			add(label);
-			ctop+=computer.resolution.getButtonHeightAndSpace();
+			ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();
 			for (String s:new String[]{"adder","negate","increment","decrement","and","or","nand","nor","not","xor","equal-to","less-than","shift-left","shift-right"})
 			{
 				button=new JButton(s);
-				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.getFontSize()));
-				button.setBounds(5,ctop,cwidth,computer.resolution.getButtonHeight());
+				button.setFont(new Font("Dialog",Font.PLAIN,computer.resolution.datapath.toolComponent.getFontSize()));
+				button.setBounds(5,ctop,cwidth,computer.resolution.datapath.toolComponent.getButtonHeight());
 				final String s2="combinational-"+s;
 				button.addActionListener(new ActionListener(){
 					public void actionPerformed(ActionEvent arg0) {
@@ -1466,7 +1468,7 @@ public class DatapathBuilder extends AbstractGUI
 						drawingcomponent.requestFocus();
 					}});
 				add(button);
-				ctop+=computer.resolution.getButtonHeightAndSpace();				
+				ctop+=computer.resolution.datapath.toolComponent.getButtonHeightAndSpace();				
 			}
 			height = ctop;
 		}

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -1,5 +1,35 @@
 package simulator;
 
+import java.awt.Dimension;
+import java.awt.Toolkit;
+
 public class Resolution {
+	public int screenWidth;
+	public int screenHeight;
+	
+	public int desktopWindowWidth;
+	public int desktopWindowHeight;
+	
+	public int buttonWidth = 100;
+	public int buttonHeight = 30;
+	public int statusHeight = 30;
+	public int desktopPanelHeight;
+	public int desktopPanelWidth;
+
+	public Resolution() {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        screenWidth = (int) screenSize.getWidth();
+        screenHeight = (int) screenSize.getHeight();
+        
+        setDesktopDimensions((int)(screenWidth * 0.7), (int)(screenHeight * 0.8));
+	}
+	
+	public void setDesktopDimensions(int newWidth, int newHeight) {
+        desktopWindowWidth = newWidth;
+        desktopWindowHeight = newHeight;
+        
+        desktopPanelWidth = desktopWindowWidth;
+    	desktopPanelHeight = desktopWindowHeight - buttonWidth - statusHeight;
+	}
 
 }

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -18,7 +18,7 @@ public class Resolution {
 	public int desktopPanelHeight;
 	public int desktopPanelWidth;
 	
-	public int defaultStatusBarWidth = 15;
+	public int defaultStatusBarWidth = 16;
 	
 	public int newComponentHeight;
 	public int newComponentWidth;
@@ -76,7 +76,7 @@ public class Resolution {
 	}
 	
 	public int getScrollbarWidth() {
-		return (int) UIManager.get("ScrollBar.width") + 1;
+		return (int) UIManager.get("ScrollBar.width") + 4;
 	}
 	public void setScrollbars() {
         UIManager.put("ScrollBar.width", (int)(defaultStatusBarWidth * multiplier));

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -13,6 +13,7 @@ public class Resolution {
 	private final int STATUS_HEIGHT = 30;
 	private final int DEFAULT_STATUS_BAR_THICKNESS = 35;
 	private final int DEFAULT_SCROLL_BAR_THICKNESS = 15;
+	private final int SCROLL_BAR_PADDING = 4;
 	
 	double multiplier;
 
@@ -24,14 +25,14 @@ public class Resolution {
 		public int width;
 		public int height;	
 		public InnerPane pane;
-		public int fontSize = 10;
-		
+		private int fontSize = 10;
+
 		public int getFontSize() {
 			return (int)(fontSize * multiplier);
 		}
 	
 		public int getScrollbarWidth() {
-			return (int) UIManager.get("ScrollBar.width") + 4;
+			return (int) UIManager.get("ScrollBar.width") + SCROLL_BAR_PADDING;
 		}
 		
 		public int getButtonHeight() {
@@ -114,6 +115,7 @@ public class Resolution {
 		}
 	}
 	
+
 	//////////////////////////
 	
 	public Resolution() {

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -11,7 +11,7 @@ public class Resolution {
 	private final int BUTTON_COMPONENT_WIDTH = 100;
 	private final int BUTTON_HEIGHT = 20;
 	private final int STATUS_HEIGHT = 30;
-	private final int DEFAULT_STATUS_BAR_THICKNESS = 30;
+	private final int DEFAULT_STATUS_BAR_THICKNESS = 35;
 	private final int DEFAULT_SCROLL_BAR_THICKNESS = 15;
 	
 	double multiplier;

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -3,82 +3,124 @@ package simulator;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 
+import javax.swing.JComponent;
 import javax.swing.UIManager;
 
 public class Resolution {
-	public int screenWidth;
-	public int screenHeight;
 	
-	public int desktopWindowWidth;
-	public int desktopWindowHeight;
+	private final int BUTTON_COMPONENT_WIDTH = 100;
+	private final int BUTTON_HEIGHT = 20;
+	private final int STATUS_HEIGHT = 30;
+	private final int DEFAULT_STATUS_BAR_THICKNESS = 15;
 	
-	public int buttonWidth = 100;
-	public int buttonHeight = 30;
-	public int statusHeight = 30;
-	public int desktopPanelHeight;
-	public int desktopPanelWidth;
-	
-	public int defaultStatusBarWidth = 16;
-	
-	public int newComponentHeight;
-	public int newComponentWidth;
-	
-	private int fontSize = 10;
 	private double scalingFactor = 0.6;
 	
 	double multiplier;
 
-	public Resolution() {
-        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-        screenWidth = (int) screenSize.getWidth();
-        screenHeight = (int) screenSize.getHeight();
-        
-        multiplier = screenWidth / 1440.0;
-        
-        setDesktopDimensions((int)(screenWidth * 0.7), (int)(screenHeight * 0.8));
+	Desktop desktop;
+	Monitor monitor;
+	Datapath datapath;
+	
+	public class AbstractWindow {
+		public int width;
+		public int height;
+		
+		public InnerPane pane;
+		
+		public int fontSize = 10;
+		
+		public int getFontSize() {
+			return (int)(fontSize * multiplier);
+		}
+	
+		public int getScrollbarWidth() {
+			return (int) UIManager.get("ScrollBar.width") + 4;
+		}
+		
+		public int getButtonHeight() {
+			return (int)(BUTTON_HEIGHT * multiplier);
+		}
+		
+		public int getButtonHeightAndSpace() {
+			return (int)(BUTTON_HEIGHT * multiplier + 5);
+		}
+		
+		public int getStatusBarThickness() {
+			return (int)(DEFAULT_STATUS_BAR_THICKNESS * multiplier);
+		}
+	}
+	public class InnerPane extends AbstractWindow{
+		public int preferredWidth;
+		public int preferredHeight;
+	}
+
+	public class InnerWindow extends AbstractWindow{
+		public InnerWindow(int width, int height) {
+			this.width = width;
+			this.height = height;
+		}
+		public InnerWindow() {
+		}
+		public InnerWindow(int width) {
+			this(width, 0);
+		}
 	}
 	
-	public void setDesktopDimensions(int newWidth, int newHeight) {
-        desktopWindowWidth = newWidth;
-        desktopWindowHeight = newHeight;
-        
-        desktopPanelWidth = desktopWindowWidth;
-        
-        // Calculate the panel size, leaving room for 3 status heights.
-        desktopPanelHeight = desktopWindowHeight - (int)(buttonHeight*3*multiplier);
-    	
-    	newComponentHeight = (int)(desktopPanelHeight * 0.8);
-    	newComponentWidth = (int)(desktopPanelWidth * 0.9);
+	public class Monitor extends AbstractWindow {
+		public Monitor() {
+	        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+	        width = (int) screenSize.getWidth();
+	        height = (int) screenSize.getHeight();
+		}
 	}
+	
+	public class Desktop extends AbstractWindow{
+		public Desktop(int screenWidth, int screenHeight) {
+			width = (int)(screenWidth * 0.7);
+			height = (int)(screenHeight * 0.8);
+			pane = new InnerPane();
+			
+			setInnerPane(width, height);
+		}
+		
+		public void setInnerPane(int basedOnWidth, int basedOnHeight) {
+	        pane.width = basedOnWidth;
+	        pane.height = basedOnHeight - (int)(BUTTON_HEIGHT*3*multiplier);
+	        pane.preferredWidth = (int)(pane.width * 0.9);
+	        pane.preferredHeight = (int)(pane.height * 0.8);
+	    }
+		
+		public void setScrollbars() {
+	        UIManager.put("ScrollBar.width", getStatusBarThickness());
+		}
+	}
+	
+	public class Datapath extends AbstractWindow {
+		InnerWindow toolComponent;
+		InnerWindow modificationComponent;
+		
+		public Datapath() {
+			width = desktop.pane.preferredWidth;
+			height = desktop.pane.preferredHeight;
+			
+			toolComponent = new InnerWindow((int)(100 * multiplier));
+			modificationComponent = new InnerWindow((int)(100 * multiplier));
+		}
+	}
+	
+	//////////////////////////
+	
+	public Resolution() {
+        monitor = new Monitor();
+        multiplier = monitor.width / 1440.0;
+        
+        desktop = new Desktop(monitor.width, monitor.height);
+        datapath = new Datapath();
+ 	}
 	
 	public double getScalingFactor() {
 		return scalingFactor + multiplier;
 	}
 	
-	public int getFontSize() {
-		return (int)(fontSize * multiplier);
-	}
 	
-	public int getDatapathToolComponentWidth() {
-		return (int)(100 * multiplier);
-	}
-	
-	public int getButtonHeight() {
-		return (int)(20 * multiplier);
-	}
-	
-	public int getButtonHeightAndSpace() {
-		return (int)(25 * multiplier);
-	}
-	
-	public int getDatapathModificationComponentWidth() {
-		return (int)(100 * multiplier);
-	}
-	
-	public int getScrollbarWidth() {
-		return (int) UIManager.get("ScrollBar.width") + 4;
-	}
-	public void setScrollbars() {
-        UIManager.put("ScrollBar.width", (int)(defaultStatusBarWidth * multiplier));
-	}
 }

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -19,13 +19,17 @@ public class Resolution {
 	public int newComponentHeight;
 	public int newComponentWidth;
 	
-	private int fontSize = 20;
-	private double scalingFactor = 1.6;
+	private int fontSize = 10;
+	private double scalingFactor = 0.6;
+	
+	double multiplier;
 
 	public Resolution() {
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         screenWidth = (int) screenSize.getWidth();
         screenHeight = (int) screenSize.getHeight();
+        
+        multiplier = screenWidth / 1440.0 + 0.5;
         
         setDesktopDimensions((int)(screenWidth * 0.7), (int)(screenHeight * 0.8));
 	}
@@ -39,29 +43,31 @@ public class Resolution {
         // Calculate the panel size, leaving room for 3 status heights.
         desktopPanelHeight = desktopWindowHeight - (buttonHeight*3);
     	
-	    	newComponentHeight = (int)(desktopPanelHeight * 0.8);
-	    	newComponentWidth = (int)(desktopPanelWidth * 0.9);
+    	newComponentHeight = (int)(desktopPanelHeight * 0.8);
+    	newComponentWidth = (int)(desktopPanelWidth * 0.9);
 	}
 	
 	public double getScalingFactor() {
-		return scalingFactor;
+		return scalingFactor + multiplier;
 	}
 	
 	public int getFontSize() {
-		return fontSize;
+		return (int)(fontSize * multiplier);
 	}
 	
 	public int getDatapathToolComponentWidth() {
-		return 150;
+		return (int)(100 * multiplier);
 	}
 	
 	public int getButtonHeight() {
-		return 45;
+		return (int)(20 * multiplier);
 	}
+	
 	public int getButtonHeightAndSpace() {
-		return 50;
+		return (int)(21 * multiplier);
 	}
+	
 	public int getDatapathModificationComponentWidth() {
-		return 150;
+		return (int)(100 * multiplier);
 	}
 }

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -7,6 +7,8 @@ import javax.swing.JComponent;
 import javax.swing.UIManager;
 
 public class Resolution {
+	public final boolean USE_SCALING_FETURE = false;
+	
 	Desktop desktop;
 	Monitor monitor;
 	Datapath datapath;
@@ -29,20 +31,23 @@ public class Resolution {
 	}
 	
 	public class Monitor extends AbstractWindow {
+		private final double STANDARD_WIDTH = 1440.0;
+		private final double STANDARD_HEIGHT = 900.0;
+		
 		public Monitor() {
 	        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
 	        
-	        width = (int) screenSize.getWidth();
-	        height = (int) screenSize.getHeight();
+	        width = USE_SCALING_FETURE ? (int) screenSize.getWidth() : (int)STANDARD_WIDTH;
+	        height = USE_SCALING_FETURE ? (int) screenSize.getHeight() : (int)STANDARD_HEIGHT;
 	        
-	        multiplier = width / 1440.0;
+	        multiplier = width / STANDARD_WIDTH;
 		}
 	}
 	
 	public class Desktop extends AbstractWindow{
-		public Desktop(int screenWidth, int screenHeight) {
-			width = (int)(screenWidth * 0.7);
-			height = (int)(screenHeight * 0.8);
+		public Desktop() {
+			width = (int)(monitor.width * 0.7);
+			height = (int)(monitor.height * 0.8);
 			pane = new InnerPane();
 			
 			setInnerPane(width, height);
@@ -84,7 +89,9 @@ public class Resolution {
 	public Resolution() {
         monitor = new Monitor();
         
-        desktop = new Desktop(monitor.width, monitor.height);
-        datapath = new Datapath();
+        System.out.println("Width: " + monitor.width + " Height: " + monitor.height);
+	    desktop = new Desktop();
+	    datapath = new Datapath();
+        
  	}
 }

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -41,7 +41,7 @@ public class Resolution {
         desktopPanelWidth = desktopWindowWidth;
         
         // Calculate the panel size, leaving room for 3 status heights.
-        desktopPanelHeight = desktopWindowHeight - (buttonHeight*3);
+        desktopPanelHeight = desktopWindowHeight - (int)(buttonHeight*3*multiplier);
     	
     	newComponentHeight = (int)(desktopPanelHeight * 0.8);
     	newComponentWidth = (int)(desktopPanelWidth * 0.9);

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -13,8 +13,6 @@ public class Resolution {
 	private final int STATUS_HEIGHT = 30;
 	private final int DEFAULT_STATUS_BAR_THICKNESS = 15;
 	
-	private double scalingFactor = 0.6;
-	
 	double multiplier;
 
 	Desktop desktop;
@@ -46,6 +44,10 @@ public class Resolution {
 		}
 		
 		public int getStatusBarThickness() {
+			return (int)(DEFAULT_STATUS_BAR_THICKNESS * multiplier);
+		}
+		
+		public int getScrollbarThickness() {
 			return (int)(DEFAULT_STATUS_BAR_THICKNESS * multiplier);
 		}
 	}
@@ -91,13 +93,14 @@ public class Resolution {
 	    }
 		
 		public void setScrollbars() {
-	        UIManager.put("ScrollBar.width", getStatusBarThickness());
+	        UIManager.put("ScrollBar.width", getScrollbarThickness());
 		}
 	}
 	
 	public class Datapath extends AbstractWindow {
 		InnerWindow toolComponent;
 		InnerWindow modificationComponent;
+		private double scalingFactor = 0.6;
 		
 		public Datapath() {
 			width = desktop.pane.preferredWidth;
@@ -105,6 +108,10 @@ public class Resolution {
 			
 			toolComponent = new InnerWindow((int)(100 * multiplier));
 			modificationComponent = new InnerWindow((int)(100 * multiplier));
+		}
+		
+		public double getScalingFactor() {
+			return scalingFactor + multiplier;
 		}
 	}
 	
@@ -117,10 +124,4 @@ public class Resolution {
         desktop = new Desktop(monitor.width, monitor.height);
         datapath = new Datapath();
  	}
-	
-	public double getScalingFactor() {
-		return scalingFactor + multiplier;
-	}
-	
-	
 }

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -7,61 +7,21 @@ import javax.swing.JComponent;
 import javax.swing.UIManager;
 
 public class Resolution {
-	
-	private final int BUTTON_COMPONENT_WIDTH = 100;
-	private final int BUTTON_HEIGHT = 20;
-	private final int STATUS_HEIGHT = 30;
-	private final int DEFAULT_STATUS_BAR_THICKNESS = 35;
-	private final int DEFAULT_SCROLL_BAR_THICKNESS = 15;
-	private final int SCROLL_BAR_PADDING = 4;
-	
-	double multiplier;
-
 	Desktop desktop;
 	Monitor monitor;
 	Datapath datapath;
-	
-	public class AbstractWindow {
-		public int width;
-		public int height;	
-		public InnerPane pane;
-		private int fontSize = 10;
-
-		public int getFontSize() {
-			return (int)(fontSize * multiplier);
-		}
-	
-		public int getScrollbarWidth() {
-			return (int) UIManager.get("ScrollBar.width") + SCROLL_BAR_PADDING;
-		}
 		
-		public int getButtonHeight() {
-			return (int)(BUTTON_HEIGHT * multiplier);
-		}
-		
-		public int getButtonHeightAndSpace() {
-			return (int)(BUTTON_HEIGHT * multiplier + 5);
-		}
-		
-		public int getStatusBarThickness() {
-			return (int)(DEFAULT_STATUS_BAR_THICKNESS * multiplier);
-		}
-		
-		public int getScrollbarThickness() {
-			return (int)(DEFAULT_SCROLL_BAR_THICKNESS * multiplier);
-		}
-	}
 	public class InnerPane extends AbstractWindow{
 		public int preferredWidth;
-		public int preferredHeight;
+		public int preferredHeight;		
 	}
 
 	public class InnerWindow extends AbstractWindow{
 		public InnerWindow(int width, int height) {
-			this.width = width;
-			this.height = height;
+			super(width, height);
 		}
 		public InnerWindow() {
+			this(0, 0);
 		}
 		public InnerWindow(int width) {
 			this(width, 0);
@@ -71,8 +31,11 @@ public class Resolution {
 	public class Monitor extends AbstractWindow {
 		public Monitor() {
 	        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+	        
 	        width = (int) screenSize.getWidth();
 	        height = (int) screenSize.getHeight();
+	        
+	        multiplier = width / 1440.0;
 		}
 	}
 	
@@ -106,8 +69,8 @@ public class Resolution {
 			width = desktop.pane.preferredWidth;
 			height = desktop.pane.preferredHeight;
 			
-			toolComponent = new InnerWindow((int)(100 * multiplier));
-			modificationComponent = new InnerWindow((int)(100 * multiplier));
+			toolComponent = new InnerWindow((int)(BUTTON_COMPONENT_WIDTH * multiplier));
+			modificationComponent = new InnerWindow((int)(BUTTON_COMPONENT_WIDTH * multiplier));
 		}
 		
 		public double getScalingFactor() {
@@ -120,7 +83,6 @@ public class Resolution {
 	
 	public Resolution() {
         monitor = new Monitor();
-        multiplier = monitor.width / 1440.0;
         
         desktop = new Desktop(monitor.width, monitor.height);
         datapath = new Datapath();

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -29,7 +29,7 @@ public class Resolution {
         screenWidth = (int) screenSize.getWidth();
         screenHeight = (int) screenSize.getHeight();
         
-        multiplier = screenWidth / 1440.0 + 0.5;
+        multiplier = screenWidth / 1440.0;
         
         setDesktopDimensions((int)(screenWidth * 0.7), (int)(screenHeight * 0.8));
 	}
@@ -64,7 +64,7 @@ public class Resolution {
 	}
 	
 	public int getButtonHeightAndSpace() {
-		return (int)(21 * multiplier);
+		return (int)(25 * multiplier);
 	}
 	
 	public int getDatapathModificationComponentWidth() {

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -11,7 +11,8 @@ public class Resolution {
 	private final int BUTTON_COMPONENT_WIDTH = 100;
 	private final int BUTTON_HEIGHT = 20;
 	private final int STATUS_HEIGHT = 30;
-	private final int DEFAULT_STATUS_BAR_THICKNESS = 15;
+	private final int DEFAULT_STATUS_BAR_THICKNESS = 30;
+	private final int DEFAULT_SCROLL_BAR_THICKNESS = 15;
 	
 	double multiplier;
 
@@ -21,10 +22,8 @@ public class Resolution {
 	
 	public class AbstractWindow {
 		public int width;
-		public int height;
-		
+		public int height;	
 		public InnerPane pane;
-		
 		public int fontSize = 10;
 		
 		public int getFontSize() {
@@ -48,7 +47,7 @@ public class Resolution {
 		}
 		
 		public int getScrollbarThickness() {
-			return (int)(DEFAULT_STATUS_BAR_THICKNESS * multiplier);
+			return (int)(DEFAULT_SCROLL_BAR_THICKNESS * multiplier);
 		}
 	}
 	public class InnerPane extends AbstractWindow{

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -15,6 +15,12 @@ public class Resolution {
 	public int statusHeight = 30;
 	public int desktopPanelHeight;
 	public int desktopPanelWidth;
+	
+	public int newComponentHeight;
+	public int newComponentWidth;
+	
+	private int fontSize = 14;
+	private double scalingFactor = 1.6;
 
 	public Resolution() {
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
@@ -29,7 +35,33 @@ public class Resolution {
         desktopWindowHeight = newHeight;
         
         desktopPanelWidth = desktopWindowWidth;
-    	desktopPanelHeight = desktopWindowHeight - buttonWidth - statusHeight;
+        
+        // Calculate the panel size, leaving room for 3 status heights.
+        desktopPanelHeight = desktopWindowHeight - (buttonHeight*3);
+    	
+	    	newComponentHeight = (int)(desktopPanelHeight * 0.8);
+	    	newComponentWidth = (int)(desktopPanelWidth * 0.9);
 	}
-
+	
+	public double getScalingFactor() {
+		return scalingFactor;
+	}
+	
+	public int getFontSize() {
+		return fontSize;
+	}
+	
+	public int getDatapathToolComponentWidth() {
+		return 150;
+	}
+	
+	public int getButtonHeight() {
+		return 45;
+	}
+	public int getButtonHeightAndSpace() {
+		return 50;
+	}
+	public int getDatapathModificationComponentWidth() {
+		return 150;
+	}
 }

--- a/src/simulator/Resolution.java
+++ b/src/simulator/Resolution.java
@@ -3,6 +3,8 @@ package simulator;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 
+import javax.swing.UIManager;
+
 public class Resolution {
 	public int screenWidth;
 	public int screenHeight;
@@ -15,6 +17,8 @@ public class Resolution {
 	public int statusHeight = 30;
 	public int desktopPanelHeight;
 	public int desktopPanelWidth;
+	
+	public int defaultStatusBarWidth = 15;
 	
 	public int newComponentHeight;
 	public int newComponentWidth;
@@ -69,5 +73,12 @@ public class Resolution {
 	
 	public int getDatapathModificationComponentWidth() {
 		return (int)(100 * multiplier);
+	}
+	
+	public int getScrollbarWidth() {
+		return (int) UIManager.get("ScrollBar.width") + 1;
+	}
+	public void setScrollbars() {
+        UIManager.put("ScrollBar.width", (int)(defaultStatusBarWidth * multiplier));
 	}
 }


### PR DESCRIPTION
Added an AbstractWindow class that manages top level resolution questions and a Resolution class that can be expanded for various classes that display windows that will need to be scaled.

Added the Resolution/scaling to the Datapath and hooks into the Desktop but did not complete the Desktop (use the Datapath as the model to go by).  Hid the resolution behind a feature flag so it can be disabled (currently that is the state).  This way it won't have any affect until we need/want it to.