### PR TITLE
Fixed issue where the Processor Design starts in a running state not …

### DIFF
--- a/src/simulator/BootGUI.java
+++ b/src/simulator/BootGUI.java
@@ -572,6 +572,22 @@ public class BootGUI extends AbstractGUI
 		{
 			memoryImage="";
 		}
+		if (singlestepbox.isSelected())
+		{
+			computer.debugMode=true;
+			computer.computerGUI.stepButton.setEnabled(true);
+			computer.computerGUI.playButton.setEnabled(true);
+			computer.computerGUI.fastPlayButton.setEnabled(true);
+			computer.computerGUI.pauseButton.setEnabled(false);
+		}
+		else
+		{
+			computer.debugMode=false;
+			computer.computerGUI.stepButton.setEnabled(false);
+			computer.computerGUI.playButton.setEnabled(false);
+			computer.computerGUI.fastPlayButton.setEnabled(false);
+			computer.computerGUI.pauseButton.setEnabled(true);
+		}
 		
 	}
 	


### PR DESCRIPTION
…a paused state

When you click Processor Design it should take you to the datapath gui and should be paused. Fixed code so that it starts paused. 