### PR TITLE
Casim 35

### DIFF
--- a/src/simulator/Computer.java
+++ b/src/simulator/Computer.java
@@ -12,7 +12,7 @@ import java.awt.Toolkit;
 import java.beans.PropertyVetoException;
 import java.io.*;
 import java.util.Scanner;
-import javax.swing.JOptionPane;
+import javax.swing.*;
 
 public class Computer
 {
@@ -275,7 +275,11 @@ public class Computer
 			try {
 				MemoryTransferGUI.load(bootgui.memoryImage, bootgui.memoryImageStart, this);
 			} catch (NullPointerException e) {
-				System.out.println("Error loading memory image");
+				final JPanel panel = new JPanel();
+
+				JOptionPane.showMessageDialog(panel, "Memory could not be loaded. Check your file path: " +
+								bootgui.memoryImage, "Warning",
+						JOptionPane.WARNING_MESSAGE);
 			}
 		}
 		

--- a/src/simulator/Computer.java
+++ b/src/simulator/Computer.java
@@ -268,8 +268,11 @@ public class Computer
 
 		if (!bootgui.memoryImage.equals(""))
 		{
-			MemoryTransferGUI.load(bootgui.memoryImage, bootgui.memoryImageStart, this);
-		}
+			try {
+				MemoryTransferGUI.load(bootgui.memoryImage, bootgui.memoryImageStart, this);
+			} catch (NullPointerException e) {
+				System.out.println("Error loading memory image");
+			}		}
 		
 		if (!bootgui.datapathxml.equals(""))
 		{

--- a/src/simulator/Computer.java
+++ b/src/simulator/Computer.java
@@ -272,7 +272,8 @@ public class Computer
 				MemoryTransferGUI.load(bootgui.memoryImage, bootgui.memoryImageStart, this);
 			} catch (NullPointerException e) {
 				System.out.println("Error loading memory image");
-			}		}
+			}
+		}
 		
 		if (!bootgui.datapathxml.equals(""))
 		{


### PR DESCRIPTION
In the boot window there is a text field for loading a path to a file containing the memory the user would like to upload. Before casim-35 if an invalid path was loaded the simulator would not run. The fix was printing the error to the console, but here I added a dialog box so the user would know for sure the memory was not loaded and the path that they tried to load from. 

To test this enter a valid and an invalid memory file path in the text field in the boot window. 